### PR TITLE
Make libs go to github when tags are built.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tests/src/test/resources/service-keys.conf.local
 .vscode
 .DS_Store
 java/*
+release_artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
     - "$HOME/bin"
 
 # build matrix
-rust: 1.34.1
+rust: 1.35.0
 matrix:
   include:
     - name: "Linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,13 @@ cache:
     - "$HOME/bin"
 
 # build matrix
-rust:
-  - 1.34.1
-os:
-  - linux
-  - osx
+rust: 1.34.1
+matrix:
+  include:
+    - name: "Linux"
+      os: linux
+    - name: "OSX"
+      os: osx
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,48 @@
 language: rust
+
+# hopefully prevent the cache from becoming huge - https://levans.fr/rust_travis_cache.html
+before_cache:
+  - rm -rf /home/travis/.cargo/registry
 cache:
   directories:
     - "$HOME/.cargo"
     - "$HOME/.ivy2/cache"
     - "$HOME/.sbt/boot/"
     - "$HOME/bin"
-# hopefully prevent the cache from becoming huge - https://levans.fr/rust_travis_cache.html
-before_cache:
-  - rm -rf /home/travis/.cargo/registry
+
+# build matrix
 rust:
   - 1.34.1
+os:
+  - linux
+  - osx
+
 branches:
   only:
     - master
+
 before_install:
   - openssl aes-256-cbc -K $encrypted_487cf28eaba8_key -iv $encrypted_487cf28eaba8_iv
     -in tests/src/test/resources/service-keys.conf.enc -out tests/src/test/resources/service-keys.conf -d
 install:
   - "~/bin/sbt --help || curl -Ls https://git.io/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt"
+
+# run tests
 before_script:
   - rustup component add rustfmt-preview
-matrix:
-  include:
-    # Linux
-    - name: Travis Default Environment (Ubuntu Linux)
-      os: linux
-    # OSX
-    - name: OSX x86_64
-      os: osx
 script:
   - "./.travis_scripts/cross-test.sh"
+
+# upload libs to github release. runs a release build first
+deploy:
+  skip_cleanup: true
+  before_deploy: ./.travis_scripts/build_release.sh
+  provider: releases
+  api-key:
+    secure: "byBjVIn1BA2Thk2ksKsj87b1WvLsF4Td+DfAZVH+N4cFRowdm8f9boBgLp24DcvIzWjaBHSKzhrqe0ACaInEhMEC6K8xfkZrwd4k8/2yDNkrTnzQcjrEF0FKxvAakoQwnYPQGpnbpzDhfKf5PhtpAVHmrJAnxx6E7HzaS+/EX98F1rAd4zcq84ih8tksp2G97aQcniEEozNJHrKfjo03dt48m8seRx3LNOO0TMogPz59y+9FB8YJeEGlfTb0hD2jC7VMZ0ULbLM3BzijOaKa3OitRkST9w06VdMxdgLrVDlf1Eeej5kaZL32G+cyaRUSaPNqjoSZezI+AWqBuJaAT+o+TzrwmJMU2RSkP/3zZXBN3dwkWF3ilDTwxygsfDhkhppC/En+4PtqFzO6odWCS8ttywUAMQvBWwgByzW8GM+vV4MoBvGGZYxZogu9sURxZiW5JvrfFsNJ2BuhbA/3gDpbfB5BmNXQ78KApirwqLXAcVXc1S3QfP3TUhWe2tAeHsRT3bOpVAKRAWBrbg4xmMNoTlEg6Op6kScqS86VVnKxHKDoU7dC68bdzm/+tXUiFxWA9LmYHqt5jxiGuZF8UZLEBaj9Xx7MByXwJkyEy/WmcxPMuP4Thwpz36yMuXC7Uf9GcHTkwR5DOAPolATLF4p5fnI8xuQn/gTIxC5TOoQ="
+  file_glob: true
+  file: release_artifacts/*
+  # only publish on tag
+  on:
+    tags: true
+  name: Version $TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 install:
   - "~/bin/sbt --help || curl -Ls https://git.io/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt"
 
-# run tests
+# tests
 before_script:
   - rustup component add rustfmt-preview
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ before_install:
 install:
   - "~/bin/sbt --help || curl -Ls https://git.io/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt"
 
-# tests
 before_script:
+  # needed for tests to run
   - rustup component add rustfmt-preview
 script:
   - "./.travis_scripts/cross-test.sh"

--- a/.travis_scripts/build-release.sh
+++ b/.travis_scripts/build-release.sh
@@ -10,7 +10,8 @@ fi
 
 cargo build --release
 
-# copy out just the library to upload
+# Copy out just the library to upload. In order to just grab the .dylib or .so we just use extglob, allowing use of |.
+# We did this instead of 2 cp lines so we could leave -e enabled and it would succeed as long as we have at least one of them.
 mkdir release_artifacts
 shopt -s extglob
 cp target/release/libironoxide_java.*(so|dylib) release_artifacts/

--- a/.travis_scripts/build-release.sh
+++ b/.travis_scripts/build-release.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+# JAVA_HOME isn't set on OSX for some reason, so manually set it
+if [ -z "$JAVA_HOME" ]; then
+    export JAVA_HOME=$(/usr/libexec/java_home)
+fi
+
+cargo b --release
+
+# copy out just the library to upload
+mkdir release_artifacts
+shopt -s extglob
+cp target/release/libironoxide_java.*(so|dylib) release_artifacts/
+shopt -u extglob

--- a/.travis_scripts/build-release.sh
+++ b/.travis_scripts/build-release.sh
@@ -8,7 +8,7 @@ if [ -z "$JAVA_HOME" ]; then
     export JAVA_HOME=$(/usr/libexec/java_home)
 fi
 
-cargo b --release
+cargo build --release
 
 # copy out just the library to upload
 mkdir release_artifacts


### PR DESCRIPTION
`skip_cleanup` may not be necessary since we're building the release as part of the deploy step. It will likely speed up that release build though, even if it isn't needed.