### PR TITLE
Update rust_swig to HEAD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: rust
 
 cache:
   directories:
-    - "$HOME/.ivy2/cache"
+    - "$HOME/.cache/coursier/v1"
     - "$HOME/.sbt/boot/"
     - "$HOME/bin"
 
 # build matrix
-rust: 1.36.0
+rust: 1.37.0
 matrix:
   include:
     - name: "Linux"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,5 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [build-dependencies]
 env_logger = "0.6"
-log = "0.4"
-rust_swig = "0.4.0"
-bindgen = "0.46"
+rust_swig = { git = "https://github.com/Dushistov/rust_swig/", rev = "f1af10fb0c1c96c9153857d18ea06a7c0644e265"}
+bindgen = "0.49"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ chrono = { version = "0.4", features = ["serde"] }
 [build-dependencies]
 env_logger = "0.6"
 log = "0.4"
-rust_swig = {git = "https://github.com/Dushistov/rust_swig.git", rev="a0ae74a" }
+rust_swig = "0.4.0"
 bindgen = "0.46"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide-java"
-version = "0.3.0"
+version = "0.5.0"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 build = "build.rs"
 edition = "2018"
@@ -13,9 +13,9 @@ crate-type = ["cdylib"]
 log = "0.4"
 itertools = "0.8"
 ironoxide = "0.10.1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = "0.4"
 
 [build-dependencies]
-env_logger = "0.6"
-rust_swig = { git = "https://github.com/Dushistov/rust_swig/", rev = "f1af10fb0c1c96c9153857d18ea06a7c0644e265"}
-bindgen = "0.49"
+env_logger = "0.7"
+rust_swig = { git = "https://github.com/Dushistov/rust_swig.git", rev = "f1af10fb0c1c96c9153857d18ea06a7c0644e265"}
+bindgen = "0.51"

--- a/src/chrono-include.rs
+++ b/src/chrono-include.rs
@@ -1,31 +1,25 @@
 mod swig_foreign_types_map {}
 
-#[swig_to_foreigner_hint = "java.util.Date"]
-impl SwigFrom<DateTime<Utc>> for jobject {
-    fn swig_from(x: DateTime<Utc>, env: *mut JNIEnv) -> Self {
-        let unix_secs = x.timestamp();
-        let mills = x.timestamp_subsec_millis();
-        let mills = (unix_secs * 1_000 + mills as i64) as jlong;
-        let date_class: jclass =
-            unsafe { (**env).FindClass.unwrap()(env, swig_c_str!("java/util/Date")) };
-        assert!(
-            !date_class.is_null(),
-            "FindClass for `java/util/Date` failed"
-        );
-        let init: jmethodID = unsafe {
-            (**env).GetMethodID.unwrap()(
-                env,
-                date_class,
-                swig_c_str!("<init>"),
-                swig_c_str!("(J)V"),
-            )
-        };
-        assert!(
-            !init.is_null(),
-            "java/util/Date GetMethodID for init failed"
-        );
-        let x = unsafe { (**env).NewObject.unwrap()(env, date_class, init, mills) };
-        assert!(!x.is_null(), "The Date object couldn't be initialized and was null.");
-        x
-    }
-}
+foreign_typemap!(
+    ($p:r_type) DateTime<Utc> => jlong {
+        $out = $p.timestamp_millis();
+    };
+    ($p:f_type, option = "NoNullAnnotations", unique_prefix = "/*chrono*/") => "/*chrono*/java.util.Date" "$out = new java.util.Date($p);";
+    ($p:f_type, option = "NullAnnotations", unique_prefix = "/*chrono*/") => "/*chrono*/@NonNull java.util.Date" "$out = new java.util.Date($p);";
+);
+
+foreign_typemap!(
+    ($p:r_type) Option<DateTime<Utc>> => internal_aliases::JOptionalLong {
+        let tmp: Option<i64> = $p.map(|x| x.timestamp_millis());
+        $out = to_java_util_optional_long(env, tmp);
+    };
+    ($p:f_type, unique_prefix = "/*chrono*/") => "/*chrono*/java.util.Optional<java.util.Date>"
+        r#"
+        $out;
+        if ($p.isPresent()) {
+            $out = java.util.Optional.of(new java.util.Date($p.getAsLong()));
+        } else {
+            $out = java.util.Optional.empty();
+        }
+"#;
+);

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -41,6 +41,7 @@ class DeviceSigningKeyPair {
 
 foreigner_class!(
 /// ID of a user. Unique with in a segment. Must match the regex `^[a-zA-Z0-9_.$#|@/:;=+'-]+$`.
+#[derive(Clone)]
 class UserId {
     self_type UserId;
     private constructor = empty;
@@ -66,6 +67,7 @@ class UserId {
 
 foreigner_class!(
 /// ID of a group. Unique within a segment. Must match the regex `^[a-zA-Z0-9_.$#|@/:;=+'-]+$`
+#[derive(Clone)]
 class GroupId {
     self_type GroupId;
     private constructor = empty;

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -4,7 +4,6 @@ use crate::{
     group_get_result::GroupUserList, document_decrypt_unmanaged_result::UserOrGroupJ
 };
 use chrono::{DateTime, Utc};
-use log::error; //This is used as part of Swig expansion as a transitive dependency
 
 ///
 /// Classes for Common Types

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -1,6 +1,6 @@
 organization := "com.ironcorelabs"
 name := "ironoxide-java"
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.9"
 
 //We're using sbt to test, but this is a pure java library for now so we don't want scala version
 //in the paths and we don't want the scala lib in the dependencies.

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -1,6 +1,6 @@
 organization := "com.ironcorelabs"
 name := "ironoxide-java"
-scalaVersion := "2.12.9"
+scalaVersion := "2.12.10"
 
 //We're using sbt to test, but this is a pure java library for now so we don't want scala version
 //in the paths and we don't want the scala lib in the dependencies.

--- a/tests/project/build.properties
+++ b/tests/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -364,7 +364,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
   }
 
   "Group add admin" should {
-    "succeed and add secordary user as an admin" in {
+    "succeed and add secondary user as an admin" in {
       val sdk = IronSdk.initialize(createDeviceContext)
 
       val addAdminResp = Try(sdk.groupAddAdmins(validGroupId, List(secondaryTestUserID).toArray)).toEither

--- a/tests/version.sbt
+++ b/tests/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.6-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
rust_swig 0.4.0 gives issues with JniInvalidValue, but that's been fixed in the current git version. 

- Replaced chrono-include.rs with the new version provided in rust_swig/jni_tests/src
- `#[derive(Clone)]` had to be added to the foreigner_class of `UserId` and `GroupId` to allow vectors of them to be used
- Updated dependencies and removed ones we didn't need.

Tests pass in ironoxide-java with `cargo t` and `sbt test`.
Tests pass in ironoxide-scala after publishing java locally and given the `libironoxide-java.so` binary