### PR TITLE
Add needsRotation to user create, user verify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.8"
-ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide.git", rev = "86d91ed344642cc00cf209438b3053def2807078"}
+ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide.git", branch = "17-changes-for-scala"}
 chrono = "0.4"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.8"
-ironoxide = "0.10.1"
+ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide.git", rev = "86d91ed344642cc00cf209438b3053def2807078"}
 chrono = "0.4"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.8"
-ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide.git", branch = "17-changes-for-scala"}
+ironoxide = "0.11.0"
 chrono = "0.4"
 
 [build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@ use ironoxide::{
     policy::{Category, DataSubject, PolicyGrant, Sensitivity},
     prelude::*,
     user::{
-        DeviceCreateOpts, UserCreateKeyPair, UserDevice, UserDeviceListResult, UserVerifyResult,
+        DeviceCreateOpts, UserCreateKeyPair, UserCreateOpts, UserDevice, UserDeviceListResult,
+        UserVerifyResult,
     },
 };
 use ironoxide::{DeviceContext, DeviceSigningKeyPair, PrivateKey, PublicKey};
@@ -202,6 +203,13 @@ mod device_create_opt {
     }
 }
 
+mod user_create_opt {
+    use super::*;
+    pub fn create(needs_rotation: bool) -> UserCreateOpts {
+        UserCreateOpts::new(needs_rotation)
+    }
+}
+
 mod policy_grant {
     use super::*;
     pub fn create(
@@ -331,6 +339,10 @@ mod user_create_key_pair {
     pub fn user_public_key(u: &UserCreateKeyPair) -> PublicKey {
         u.user_public_key().clone()
     }
+
+    pub fn needs_rotation(u: &UserCreateKeyPair) -> bool {
+        u.needs_rotation()
+    }
 }
 
 mod user_verify_result {
@@ -345,6 +357,10 @@ mod user_verify_result {
 
     pub fn segment_id(u: &UserVerifyResult) -> usize {
         u.segment_id()
+    }
+
+    pub fn needs_rotation(u: &UserVerifyResult) -> bool {
+        u.needs_rotation()
     }
 }
 
@@ -726,8 +742,12 @@ mod group_create_opts {
 fn user_verify(jwt: &str) -> Result<Option<UserVerifyResult>, String> {
     Ok(IronOxide::user_verify(jwt)?)
 }
-fn user_create(jwt: &str, password: &str) -> Result<UserCreateKeyPair, String> {
-    Ok(IronOxide::user_create(jwt, password)?)
+fn user_create(
+    jwt: &str,
+    password: &str,
+    opts: &UserCreateOpts,
+) -> Result<UserCreateKeyPair, String> {
+    Ok(IronOxide::user_create(jwt, password, opts)?)
 }
 fn initialize(init: &DeviceContext) -> Result<IronOxide, String> {
     Ok(ironoxide::initialize(init)?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,10 @@ mod device_name {
 
 mod public_key {
     use super::*;
+    use std::convert::TryInto;
+    pub fn validate(bytes: &[i8]) -> Result<PublicKey, String> {
+        Ok(i8_conv(bytes).try_into()?)
+    }
     pub fn as_bytes(pk: &PublicKey) -> Vec<i8> {
         u8_conv(&pk.as_bytes()[..]).to_vec()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use ironoxide::{
     policy::{Category, DataSubject, PolicyGrant, Sensitivity},
     prelude::*,
     user::{
-        DeviceCreateOpts, UserCreateKeyPair, UserCreateOpts, UserDevice, UserDeviceListResult,
+        DeviceCreateOpts, UserCreateOpts, UserCreateResult, UserDevice, UserDeviceListResult,
         UserVerifyResult,
     },
 };
@@ -200,14 +200,14 @@ mod device_signing_keys {
     }
 }
 
-mod device_create_opt {
+mod device_create_opts {
     use super::*;
     pub fn create(name: Option<DeviceName>) -> DeviceCreateOpts {
         DeviceCreateOpts::new(name)
     }
 }
 
-mod user_create_opt {
+mod user_create_opts {
     use super::*;
     pub fn create(needs_rotation: bool) -> UserCreateOpts {
         UserCreateOpts::new(needs_rotation)
@@ -334,17 +334,12 @@ mod device_context {
     }
 }
 
-mod user_create_key_pair {
+mod user_create_result {
     use super::*;
-    pub fn user_encrypted_master_key_bytes(u: &UserCreateKeyPair) -> Vec<i8> {
-        u8_conv(&u.user_encrypted_master_key_bytes()[..]).to_vec()
-    }
-
-    pub fn user_public_key(u: &UserCreateKeyPair) -> PublicKey {
+    pub fn user_public_key(u: &UserCreateResult) -> PublicKey {
         u.user_public_key().clone()
     }
-
-    pub fn needs_rotation(u: &UserCreateKeyPair) -> bool {
+    pub fn needs_rotation(u: &UserCreateResult) -> bool {
         u.needs_rotation()
     }
 }
@@ -750,7 +745,7 @@ fn user_create(
     jwt: &str,
     password: &str,
     opts: &UserCreateOpts,
-) -> Result<UserCreateKeyPair, String> {
+) -> Result<UserCreateResult, String> {
     Ok(IronOxide::user_create(jwt, password, opts)?)
 }
 fn initialize(init: &DeviceContext) -> Result<IronOxide, String> {

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -319,14 +319,12 @@ class DeviceContext {
 
 foreigner_class!(
 /// Keypair for a newly created user.
-class UserCreateKeyPair {
-    self_type UserCreateKeyPair;
+class UserCreateResult {
+    self_type UserCreateResult;
     private constructor = empty;
-    /// user's private key encrypted with the provided passphrase
-    method user_create_key_pair::user_encrypted_master_key_bytes(&self) -> Vec<i8>; alias getUserEncryptedMasterKey;
-    method user_create_key_pair::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
+    method user_create_result::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
     /// True if the private key of the user's keypair needs to be rotated, else false.
-    method user_create_key_pair::needs_rotation(&self) -> bool; alias getNeedsRotation;
+    method user_create_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
 });
 
 foreigner_class!(
@@ -362,7 +360,7 @@ foreigner_class!(class DeviceCreateOpts {
     self_type DeviceCreateOpts;
     //Construct the DeviceCreateOpts with None for name.
     constructor DeviceCreateOpts::default() -> DeviceCreateOpts;
-    static_method device_create_opt::create(_:Option<DeviceName>) -> DeviceCreateOpts;
+    static_method device_create_opts::create(_:Option<DeviceName>) -> DeviceCreateOpts;
 });
 
 foreigner_class!(
@@ -371,7 +369,7 @@ foreigner_class!(
         self_type UserCreateOpts;
         //Construct the UserCreateOpts with a needs_rotation of false.
         constructor UserCreateOpts::default() -> UserCreateOpts;
-        static_method user_create_opt::create(_: bool) -> UserCreateOpts;
+        static_method user_create_opts::create(_: bool) -> UserCreateOpts;
     }
 );
 
@@ -687,14 +685,26 @@ foreigner_class!(
 class IronSdk {
     self_type IronOxide;
     private constructor = empty;
-    static_method user_verify(_:&str) -> Result<Option<UserVerifyResult>, String>; alias userVerify;
-    static_method user_create(_:&str, _:&str, _:&UserCreateOpts) -> Result<UserCreateKeyPair, String>; alias userCreate;
+    /// Verify a user given a JWT for their user record.
+    ///
+    /// @param jwt valid IronCore JWT
+    /// @return option of whether the user's account record exists in the IronCore system or not. Error if the request couldn't be made.
+    static_method user_verify(jwt:&str) -> Result<Option<UserVerifyResult>, String>; alias userVerify;
+   /// Create a new user within the IronCore system.
+   ///
+   /// @param jwt       valid IronCore or Auth0 JWT
+   /// @param password  password used to encrypt and escrow the user's private master key
+   /// @param options   see {@link UserCreateOpts}. Use `new UserCreateOpts()` for defaults
+   /// @return see {@link UserCreateResult}. For most use cases, the public key can be discarded as IronCore escrows your user's keys.
+   ///         The escrowed keys are unlocked by the provided password.
+    static_method user_create(jwt:&str, password:&str, options:&UserCreateOpts) -> Result<UserCreateResult, String>; alias userCreate;
     /// Initialize IronSdk with a device. Verifies that the provided user/segment exists and the provided device
     /// keys are valid and exist for the provided account.
     /// 
+    /// @param init device context used to initialize the IronSdk with a set of device keys
     /// @throws java.lang.Exception if the provided `DeviceContext` is invalid
     /// @return an instance of the IronSdk
-    static_method initialize(_:&DeviceContext) -> Result<IronOxide, String>;
+    static_method initialize(init:&DeviceContext) -> Result<IronOxide, String>;
     /// Generates a new device for the user specified in the signed JWT.
     ///
     /// This will result in a new transform key (from the user's master private key to the new device's public key)
@@ -802,7 +812,7 @@ class IronSdk {
     method group_get_metadata(&self, id:&GroupId) -> Result<GroupGetResult, String>; alias groupGetMetadata;
     /// Create a group. The creating user will become a group admin.
     ///
-    /// @param groupCreateOpts see {@link GroupCreateOpts}. Use `new GroupGreateOpts()` for defaults
+    /// @param groupCreateOpts see {@link GroupCreateOpts}. Use `new GroupCreateOpts()` for defaults
     method group_create(&self, groupCreateOpts: &GroupCreateOpts) -> Result<GroupMetaResult, String>; alias groupCreate;
     /// Update a group name to a new value or clear its value.
     ///

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -324,6 +324,8 @@ class UserCreateKeyPair {
     /// user's private key encrypted with the provided passphrase
     method user_create_key_pair::user_encrypted_master_key_bytes(&self) -> Vec<i8>; alias getUserEncryptedMasterKey;
     method user_create_key_pair::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
+    /// True if the private key of the user's keypair needs to be rotated, else false.
+    method user_create_key_pair::needs_rotation(&self) -> bool; alias getNeedsRotation;
 });
 
 foreigner_class!(
@@ -334,6 +336,7 @@ class UserVerifyResult {
     method user_verify_result::account_id(&self) -> UserId; alias getAccountId;
     method user_verify_result::segment_id(&self) -> usize; alias getSegmentId;
     method user_verify_result::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
+    method user_verify_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
 });
 
 foreigner_class!(
@@ -360,6 +363,16 @@ foreigner_class!(class DeviceCreateOpts {
     constructor DeviceCreateOpts::default() -> DeviceCreateOpts;
     static_method device_create_opt::create(_:Option<DeviceName>) -> DeviceCreateOpts;
 });
+
+foreigner_class!(
+    /// Options that can be specified creating a user.
+    class UserCreateOpts {
+        self_type UserCreateOpts;
+        //Construct the UserCreateOpts with a needs_rotation of false.
+        constructor UserCreateOpts::default() -> UserCreateOpts;
+        static_method user_create_opt::create(_: bool) -> UserCreateOpts;
+    }
+);
 
 foreigner_class!(
 /// Devices for a user, sorted by the device id.
@@ -674,7 +687,7 @@ class IronSdk {
     self_type IronOxide;
     private constructor = empty;
     static_method user_verify(_:&str) -> Result<Option<UserVerifyResult>, String>; alias userVerify;
-    static_method user_create(_:&str, _:&str) -> Result<UserCreateKeyPair, String>; alias userCreate;
+    static_method user_create(_:&str, _:&str, _:&UserCreateOpts) -> Result<UserCreateKeyPair, String>; alias userCreate;
     /// Initialize IronSdk with a device. Verifies that the provided user/segment exists and the provided device
     /// keys are valid and exist for the provided account.
     /// 

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -15,6 +15,7 @@ foreigner_class!(
 class PublicKey {
     self_type PublicKey;
     private constructor = empty;
+    static_method public_key::validate(&[i8]) -> Result<PublicKey, String>;
     method public_key::as_bytes(&self) -> Vec<i8>; alias asBytes;
 });
 

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -40,16 +40,17 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
   "User Create" should {
     "successfully create a new user" in {
       val jwt = JwtHelper.generateValidJwt(primaryTestUserId.getId)
-      val resp = Try(IronSdk.userCreate(jwt, primaryTestUserPassword)).toEither
+      val resp = Try(IronSdk.userCreate(jwt, primaryTestUserPassword, UserCreateOpts.create(true))).toEither
       val createResult = resp.value
 
       createResult.getUserEncryptedMasterKey should have length 92
       createResult.getUserPublicKey.asBytes should have length 64
+      createResult.getNeedsRotation shouldBe true
     }
 
     "successfully create a 2nd new user" in {
       val jwt = JwtHelper.generateValidJwt(secondaryTestUserID.getId)
-      val resp = Try(IronSdk.userCreate(jwt, secondaryTestUserPassword)).toEither
+      val resp = Try(IronSdk.userCreate(jwt, secondaryTestUserPassword, new UserCreateOpts())).toEither
       val createResult = resp.value
 
       //Store off the new user we created so it can used for future tests below
@@ -57,6 +58,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
       createResult.getUserEncryptedMasterKey should have length 92
       createResult.getUserPublicKey.asBytes should have length 64
+      createResult.getNeedsRotation shouldBe false
     }
   }
 
@@ -80,6 +82,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
       verifyResult.get.getAccountId shouldBe primaryTestUserId
       verifyResult.get.getSegmentId shouldBe 2013
+      verifyResult.get.getNeedsRotation shouldBe true
     }
   }
 

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -18,7 +18,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
   val secondaryTestUserID = Try(UserId.validate(java.util.UUID.randomUUID().toString())).toEither.value
   val secondaryTestUserPassword = java.util.UUID.randomUUID().toString()
 
-  var secondaryUserRecord: UserCreateKeyPair = null
+  var secondaryUserRecord: UserCreateResult = null
 
   var validGroupId: GroupId = null
   var validDocumentId: DocumentId = null
@@ -43,7 +43,6 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val resp = Try(IronSdk.userCreate(jwt, primaryTestUserPassword, UserCreateOpts.create(true))).toEither
       val createResult = resp.value
 
-      createResult.getUserEncryptedMasterKey should have length 92
       createResult.getUserPublicKey.asBytes should have length 64
       createResult.getNeedsRotation shouldBe true
     }
@@ -56,7 +55,6 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       //Store off the new user we created so it can used for future tests below
       secondaryUserRecord = createResult
 
-      createResult.getUserEncryptedMasterKey should have length 92
       createResult.getUserPublicKey.asBytes should have length 64
       createResult.getNeedsRotation shouldBe false
     }

--- a/tests/src/test/scala/ironrust/UserCreateFailureTest.scala
+++ b/tests/src/test/scala/ironrust/UserCreateFailureTest.scala
@@ -6,7 +6,7 @@ import scala.util.Try
 class UserCreateFailureTest extends DudeSuite {
   "userCreate" should {
     "return error for fixed jwt" in {
-      val badResponseTry = Try(IronSdk.userCreate("foo", "bar")).toEither
+      val badResponseTry = Try(IronSdk.userCreate("foo", "bar", UserCreateOpts.create(true))).toEither
       badResponseTry.leftValue.getMessage should include(
         """must be valid ascii and be formatted correctly"""
       )
@@ -14,7 +14,7 @@ class UserCreateFailureTest extends DudeSuite {
     "return error for outdated jwt" in {
       val jwt =
         "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NTA3NzE4MjMsImlhdCI6MTU1MDc3MTcwMywia2lkIjo1NTEsInBpZCI6MTAxMiwic2lkIjoidGVzdC1zZWdtZW50Iiwic3ViIjoiYTAzYjhlNTYtMTVkMi00Y2Y3LTk0MWYtYzYwMWU1NzUxNjNiIn0.vlqt0da5ltA2dYEK9i_pfRxPd3K2uexnkbAbzmbjW65XNcWlBOIbcdmmQLnSIZkRyTORD3DLXOIPYbGlApaTCR5WbaR3oPiSsR9IqdhgMEZxCcarqGg7b_zzwTP98fDcALGZNGsJL1hIrl3EEXdPoYjsOJ5LMF1H57NZiteBDAsm1zfXgOgCtvCdt7PQFSCpM5GyE3und9VnEgjtcQ6HAZYdutqjI79vaTnjt2A1X38pbHcnfvSanzJoeU3szwtBiVlB3cfXbROvBC7Kz8KvbWJzImJcJiRT-KyI4kk3l8wAs2FUjSRco8AQ1nIX21QHlRI0vVr_vdOd_pTXOUU51g"
-      val resp = Try(IronSdk.userCreate(jwt, "foo")).toEither
+      val resp = Try(IronSdk.userCreate(jwt, "foo", UserCreateOpts.create(true))).toEither
       resp.leftValue.getMessage should include(
         """ServerError { message: "\'jwt ey"""
       )


### PR DESCRIPTION
- `needsRotation` can be specified through `UserCreateOpts` when creating a user
- Default `needsRotation` is false
- `needsRotation` will be returned by user verify