### PR TITLE
Support group private key rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,14 +335,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.2"
+version = "1.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -731,8 +730,8 @@ dependencies = [
 
 [[package]]
 name = "ironoxide"
-version = "0.14.0"
-source = "git+https://github.com/IronCoreLabs/ironoxide?branch=45-group-key-rotation#be5fdc0138bf8c90785f63927658dd8441ab621a"
+version = "0.14.1"
+source = "git+https://github.com/IronCoreLabs/ironoxide?branch=rotate_all#276adca29466b8759241e0fdcae0a6c6713aa22a"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64-serde 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -750,7 +749,7 @@ dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "recrypt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "recrypt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -769,7 +768,7 @@ dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ironoxide 0.14.0 (git+https://github.com/IronCoreLabs/ironoxide?branch=45-group-key-rotation)",
+ "ironoxide 0.14.1 (git+https://github.com/IronCoreLabs/ironoxide?branch=rotate_all)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=f1af10fb0c1c96c9153857d18ea06a7c0644e265)",
@@ -1340,13 +1339,13 @@ dependencies = [
 
 [[package]]
 name = "recrypt"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gridiron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2228,7 +2227,7 @@ dependencies = [
 "checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
-"checksum ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)" = "845aaacc16f01178f33349e7c992ecd0cee095aa5e577f0f4dee35971bd36455"
+"checksum ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81956bcf7ef761fb4e1d88de3fa181358a0d26cbcb9755b587a08f9119824b86"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
@@ -2273,7 +2272,7 @@ dependencies = [
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum ironoxide 0.14.0 (git+https://github.com/IronCoreLabs/ironoxide?branch=45-group-key-rotation)" = "<none>"
+"checksum ironoxide 0.14.1 (git+https://github.com/IronCoreLabs/ironoxide?branch=rotate_all)" = "<none>"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1c840fdb2167497b0bd0db43d6dfe61e91637fa72f9d061f8bd17ddc44ba6414"
@@ -2341,7 +2340,7 @@ dependencies = [
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum recrypt 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f796bbe39b3ad290d766bbdd829de3136697f0279b52323de32903533f10f337"
+"checksum recrypt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "90e05c800cb7778bb3c7a18769da10f5de729ab00b963246dbf3e170f88f29b6"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,8 +730,8 @@ dependencies = [
 
 [[package]]
 name = "ironoxide"
-version = "0.14.1"
-source = "git+https://github.com/IronCoreLabs/ironoxide?branch=rotate_all#276adca29466b8759241e0fdcae0a6c6713aa22a"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64-serde 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -763,12 +763,12 @@ dependencies = [
 
 [[package]]
 name = "ironoxide-java"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ironoxide 0.14.1 (git+https://github.com/IronCoreLabs/ironoxide?branch=rotate_all)",
+ "ironoxide 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=f1af10fb0c1c96c9153857d18ea06a7c0644e265)",
@@ -2272,7 +2272,7 @@ dependencies = [
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum ironoxide 0.14.1 (git+https://github.com/IronCoreLabs/ironoxide?branch=rotate_all)" = "<none>"
+"checksum ironoxide 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d97a9e85ec7f938706fd4674a327ecb126b887c8ca37c31da96f7a855738feb4"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1c840fdb2167497b0bd0db43d6dfe61e91637fa72f9d061f8bd17ddc44ba6414"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 [[package]]
 name = "ironoxide"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/IronCoreLabs/ironoxide?branch=45-group-key-rotation#be5fdc0138bf8c90785f63927658dd8441ab621a"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64-serde 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -769,7 +769,7 @@ dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ironoxide 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ironoxide 0.14.0 (git+https://github.com/IronCoreLabs/ironoxide?branch=45-group-key-rotation)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=f1af10fb0c1c96c9153857d18ea06a7c0644e265)",
@@ -2273,7 +2273,7 @@ dependencies = [
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum ironoxide 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe1ebef17c065d9aeb718618f9567479c877a28c5ba160ad183d6cbfaa5178d1"
+"checksum ironoxide 0.14.0 (git+https://github.com/IronCoreLabs/ironoxide?branch=45-group-key-rotation)" = "<none>"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1c840fdb2167497b0bd0db43d6dfe61e91637fa72f9d061f8bd17ddc44ba6414"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide-java"
-version = "0.8.0"
+version = "0.8.2"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 build = "build.rs"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.8"
-ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide", branch = "45-group-key-rotation"}
+ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide", branch = "rotate_all"}
 chrono = "0.4"
 serde_json = "~1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.8"
-ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide", branch = "rotate_all"}
+ironoxide = "0.15.0"
 chrono = "0.4"
 serde_json = "~1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.8"
-ironoxide = "~0.14.0"
+ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide", branch = "45-group-key-rotation"}
 chrono = "0.4"
 serde_json = "~1.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -812,6 +812,9 @@ mod group_update_private_key_result {
     pub fn needs_rotation(g: &GroupUpdatePrivateKeyResult) -> bool {
         g.needs_rotation()
     }
+    pub fn id(g: &GroupUpdatePrivateKeyResult) -> GroupId {
+        g.id().clone()
+    }
 }
 
 mod group_create_opts {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use ironoxide::{
     },
     group::{
         GroupAccessEditErr, GroupAccessEditResult, GroupCreateOpts, GroupCreateResult,
-        GroupGetResult, GroupListResult, GroupMetaResult,
+        GroupGetResult, GroupListResult, GroupMetaResult, GroupUpdatePrivateKeyResult,
     },
     policy::{Category, DataSubject, PolicyGrant, Sensitivity},
     prelude::*,
@@ -807,6 +807,13 @@ mod group_get_result {
     }
 }
 
+mod group_update_private_key_result {
+    use super::*;
+    pub fn needs_rotation(g: &GroupUpdatePrivateKeyResult) -> bool {
+        g.needs_rotation()
+    }
+}
+
 mod group_create_opts {
     use super::*;
     pub fn create(
@@ -1004,6 +1011,12 @@ fn group_remove_admins(
     users: Vec<UserId>,
 ) -> Result<GroupAccessEditResult, String> {
     Ok(sdk.group_remove_admins(group_id, &users)?)
+}
+fn group_rotate_private_key(
+    sdk: &IronOxide,
+    group_id: &GroupId,
+) -> Result<GroupUpdatePrivateKeyResult, String> {
+    Ok(sdk.group_rotate_private_key(group_id)?)
 }
 
 mod group_access_edit_result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -856,13 +856,8 @@ fn initialize(init: &DeviceContext) -> Result<IronOxide, String> {
 fn initialize_and_rotate(init: &DeviceContext, password: &str) -> Result<IronOxide, String> {
     Ok(match ironoxide::initialize_check_rotation(init)? {
         InitAndRotationCheck::RotationNeeded(ironoxide, rotation) => {
-            match rotation.user_rotation_needed() {
-                Some(_) => {
-                    ironoxide.user_rotate_private_key(password)?;
-                    ironoxide
-                }
-                None => ironoxide,
-            }
+            rotation.rotate_all(&ironoxide, password)?;
+            ironoxide
         }
         InitAndRotationCheck::NoRotationNeeded(ironoxide) => ironoxide,
     })

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -1002,7 +1002,7 @@ class IronSdk {
     /// IronCore webservice.
     /// Note: You must be an admin of the group in order to rotate its private key.
     /// 
-    /// @param id ID of the group you wish to rotate the private key of
+    /// @param id id of the group you wish to rotate the private key of
     /// @return The id of the group whose private key got updated and associated metadata
     method group_rotate_private_key(&self, id:&GroupId) -> Result<GroupUpdatePrivateKeyResult, String>; alias groupRotatePrivateKey;
 });

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -533,6 +533,8 @@ foreigner_class!(class GroupUpdatePrivateKeyResult{
     private constructor = empty;
     /// true if the group still needs rotation, else false
     method group_update_private_key_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
+    /// the id of the group whose private key was rotated
+    method group_update_private_key_result::id(&self) -> GroupId; alias getId;
 });
 
 foreigner_class!(
@@ -995,6 +997,12 @@ class IronSdk {
     ///
     /// @return list of users that were removed and the users that failed to be removed with the reason they were not
     method group_remove_admins(&self, id:&GroupId, userRevokes: Vec<UserId>) -> Result<GroupAccessEditResult, String>; alias groupRemoveAdmins;
-    //TODO: docs
+    /// Rotate the provided group's private key, but leave the public key the same.
+    /// There's no black magic here! This is accomplished via multi-party computation with the
+    /// IronCore webservice.
+    /// Note: You must be an admin of the group in order to rotate its private key.
+    /// 
+    /// @param id ID of the group you wish to rotate the private key of
+    /// @return The id of the group whose private key got updated and associated metadata
     method group_rotate_private_key(&self, id:&GroupId) -> Result<GroupUpdatePrivateKeyResult, String>; alias groupRotatePrivateKey;
 });

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -528,6 +528,13 @@ foreigner_class!(class GroupGetResult{
     method group_get_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
 });
 
+foreigner_class!(class GroupUpdatePrivateKeyResult{
+    self_type GroupUpdatePrivateKeyResult;
+    private constructor = empty;
+    /// true if the group still needs rotation, else false
+    method group_update_private_key_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
+});
+
 foreigner_class!(
 /// Options for group creation.
 class GroupCreateOpts {
@@ -988,4 +995,6 @@ class IronSdk {
     ///
     /// @return list of users that were removed and the users that failed to be removed with the reason they were not
     method group_remove_admins(&self, id:&GroupId, userRevokes: Vec<UserId>) -> Result<GroupAccessEditResult, String>; alias groupRemoveAdmins;
+    //TODO: docs
+    method group_rotate_private_key(&self, id:&GroupId) -> Result<GroupUpdatePrivateKeyResult, String>; alias groupRotatePrivateKey;
 });

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -830,7 +830,7 @@ class IronSdk {
     /// Initialize IronSdk with a device. Verifies that the provided user/segment exists and the provided device
     /// keys are valid and exist for the provided account.
     /// After initialization, checks whether the calling user's private key needs rotation and rotates it 
-    /// if necessary.
+    /// if necessary, then does the same for each group the user is an admin of.
     /// 
     /// @param init device context used to initialize the IronSdk with a set of device keys
     /// @param password password used to encrypt and escrow the user's private master key

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -307,6 +307,24 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
   }
 
+  "Group Private Key Rotate" should {
+    "Successfully rotate a valid group" in {
+      val sdk = IronSdk.initialize(createDeviceContext)
+      val rotateResult = sdk.groupRotatePrivateKey(validGroupId)
+      rotateResult.getNeedsRotation shouldBe false
+    }
+    "Fail for non-admin" in {
+      val sdk = IronSdk.initialize(createSecondaryDeviceContext)
+      val rotateResult = Try(sdk.groupRotatePrivateKey(validGroupId)).toEither
+      rotateResult.isLeft shouldBe true
+    }
+    "Fail for invalid group" in {
+      val sdk = IronSdk.initialize(createDeviceContext)
+      val rotateResult = Try(sdk.groupRotatePrivateKey(GroupId.validate("7584"))).toEither
+      rotateResult.isLeft shouldBe true
+    }
+  }
+
   "Group List" should {
     "Return previously created group" in {
       val sdk = IronSdk.initialize(createDeviceContext)
@@ -352,7 +370,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       group.getAdminList.get.getList.head shouldBe primaryTestUserId
       group.getMemberList.get.getList should have length 1
       group.getMemberList.get.getList.head shouldBe primaryTestUserId
-      group.getNeedsRotation.get.getBoolean shouldBe true
+      group.getNeedsRotation.get.getBoolean shouldBe false
     }
 
     "succeed for a non-member" in {

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -312,6 +312,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val sdk = IronSdk.initialize(createDeviceContext)
       val rotateResult = sdk.groupRotatePrivateKey(validGroupId)
       rotateResult.getNeedsRotation shouldBe false
+      rotateResult.getId shouldBe validGroupId
     }
     "Fail for non-admin" in {
       val sdk = IronSdk.initialize(createSecondaryDeviceContext)


### PR DESCRIPTION
- Added `groupRotatePrivateKey()`
- Added `GroupPrivateKeyUpdateResult`
- Changed `initializeAndRotate()` to include groups needing rotation

TODO: 
- [x] Depend on ironoxide 0.15.0 when released