### PR TITLE
Remove deviceId from DeviceContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,6 @@ dependencies = [
 [[package]]
 name = "ironoxide"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64-serde 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -768,7 +767,7 @@ dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ironoxide 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ironoxide 0.15.0",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=f1af10fb0c1c96c9153857d18ea06a7c0644e265)",
@@ -2272,7 +2271,6 @@ dependencies = [
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum ironoxide 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d97a9e85ec7f938706fd4674a327ecb126b887c8ca37c31da96f7a855738feb4"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1c840fdb2167497b0bd0db43d6dfe61e91637fa72f9d061f8bd17ddc44ba6414"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "ironoxide-java"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,8 +730,8 @@ dependencies = [
 
 [[package]]
 name = "ironoxide"
-version = "0.15.0"
-source = "git+https://github.com/IronCoreLabs/ironoxide.git?branch=78-remove-device-context-id#9a1fd6bcb04500810a8c60a29d129e0e09ac631d"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64-serde 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -768,7 +768,7 @@ dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ironoxide 0.15.0 (git+https://github.com/IronCoreLabs/ironoxide.git?branch=78-remove-device-context-id)",
+ "ironoxide 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=f1af10fb0c1c96c9153857d18ea06a7c0644e265)",
@@ -2272,7 +2272,7 @@ dependencies = [
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum ironoxide 0.15.0 (git+https://github.com/IronCoreLabs/ironoxide.git?branch=78-remove-device-context-id)" = "<none>"
+"checksum ironoxide 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fde154780918e80a175f22d20059d93aa4aec0b9a205c6177b74493814af8bdf"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1c840fdb2167497b0bd0db43d6dfe61e91637fa72f9d061f8bd17ddc44ba6414"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
 [[package]]
 name = "ironoxide"
 version = "0.15.0"
+source = "git+https://github.com/IronCoreLabs/ironoxide.git?branch=78-remove-device-context-id#9a1fd6bcb04500810a8c60a29d129e0e09ac631d"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64-serde 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -767,7 +768,7 @@ dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ironoxide 0.15.0",
+ "ironoxide 0.15.0 (git+https://github.com/IronCoreLabs/ironoxide.git?branch=78-remove-device-context-id)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=f1af10fb0c1c96c9153857d18ea06a7c0644e265)",
@@ -2271,6 +2272,7 @@ dependencies = [
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+"checksum ironoxide 0.15.0 (git+https://github.com/IronCoreLabs/ironoxide.git?branch=78-remove-device-context-id)" = "<none>"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1c840fdb2167497b0bd0db43d6dfe61e91637fa72f9d061f8bd17ddc44ba6414"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.8"
-ironoxide = "0.15.0"
+ironoxide = {path = "../ironoxide"}
 chrono = "0.4"
 serde_json = "~1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.8"
-ironoxide = {path = "../ironoxide"}
+ironoxide = {git = "https://github.com/IronCoreLabs/ironoxide.git", branch = "78-remove-device-context-id"}
 chrono = "0.4"
 serde_json = "~1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.8"
-ironoxide = {git = "https://github.com/IronCoreLabs/ironoxide.git", branch = "78-remove-device-context-id"}
+ironoxide = "0.16.0"
 chrono = "0.4"
 serde_json = "~1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide-java"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 build = "build.rs"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,14 +316,12 @@ mod document_create_opt {
 mod device_context {
     use super::*;
     pub fn new(
-        device_id: &DeviceId,
         account_id: &UserId,
         segment_id: i64,
         device_private_key: &PrivateKey,
         signing_private_key: &DeviceSigningKeyPair,
     ) -> DeviceContext {
         DeviceContext::new(
-            device_id.clone(),
             account_id.clone(),
             segment_id as usize,
             device_private_key.clone(),
@@ -344,10 +342,6 @@ mod device_context {
 
     pub fn signing_private_key(d: &DeviceContext) -> DeviceSigningKeyPair {
         d.signing_private_key().clone()
-    }
-
-    pub fn device_id(d: &DeviceContext) -> DeviceId {
-        d.device_id().clone()
     }
 
     pub fn to_json_string(d: &DeviceContext) -> String {

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -361,11 +361,10 @@ foreigner_class!(class GroupUserList {
 ///
 
 foreigner_class!(
-// #[derive(Serialize, Deserialize)]
-/// Accounts device context. Needed to initialize the Sdk with a set of device keys. See `Sdk.initialize()`
+/// Account's device context. Needed to initialize the Sdk with a set of device keys. See `Sdk.initialize()`
 class DeviceContext {
     self_type DeviceContext;
-    constructor device_context::new( accountId: &UserId, segmentId: i64, devicePrivateKey: &PrivateKey, signingPrivateKey: &DeviceSigningKeyPair) -> DeviceContext;
+    constructor device_context::new(accountId: &UserId, segmentId: i64, devicePrivateKey: &PrivateKey, signingPrivateKey: &DeviceSigningKeyPair) -> DeviceContext;
     method device_context::account_id(&self) -> UserId; alias getAccountId;
     method device_context::segment_id(&self) -> usize; alias getSegmentId;
     method device_context::device_private_key(&self) -> PrivateKey; alias getDevicePrivateKey;

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -365,8 +365,7 @@ foreigner_class!(
 /// Accounts device context. Needed to initialize the Sdk with a set of device keys. See `Sdk.initialize()`
 class DeviceContext {
     self_type DeviceContext;
-    constructor device_context::new(deviceId: &DeviceId, accountId: &UserId, segmentId: i64, devicePrivateKey: &PrivateKey, signingPrivateKey: &DeviceSigningKeyPair) -> DeviceContext;
-    method device_context::device_id(&self) -> DeviceId; alias getDeviceId;
+    constructor device_context::new( accountId: &UserId, segmentId: i64, devicePrivateKey: &PrivateKey, signingPrivateKey: &DeviceSigningKeyPair) -> DeviceContext;
     method device_context::account_id(&self) -> UserId; alias getAccountId;
     method device_context::segment_id(&self) -> usize; alias getSegmentId;
     method device_context::device_private_key(&self) -> PrivateKey; alias getDevicePrivateKey;

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -25,7 +25,6 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   var validGroupId: GroupId = null
   var validDocumentId: DocumentId = null
-  val validDeviceId: DeviceId = DeviceId.validate(1)
 
   /**
     * Convenience function to create a new DeviceContext instance from the stored off components we need. Takes the
@@ -34,7 +33,6 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     */
   def createDeviceContext = {
     new DeviceContext(
-      validDeviceId,
       primaryTestUserId,
       primaryTestUserSegmentId,
       PrivateKey.validate(primaryTestUserPrivateDeviceKeyBytes),
@@ -44,7 +42,6 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   def createSecondaryDeviceContext = {
     new DeviceContext(
-      validDeviceId,
       secondaryTestUserId,
       secondaryTestUserSegmentId,
       PrivateKey.validate(secondaryTestUserPrivateDeviceKeyBytes),
@@ -144,18 +141,16 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val deviceContext =
         IronSdk.generateNewDevice(jwt, secondaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone))
       val json = deviceContext.toJsonString
-      val deviceId = deviceContext.getDeviceId.getId
       val accountId = deviceContext.getAccountId.getId
       val segmentId = deviceContext.getSegmentId
       val signingPrivateKeyBase64 = ByteVector.view(deviceContext.getSigningPrivateKey.asBytes).toBase64
       val devicePrivateKeyBase64 = ByteVector.view(deviceContext.getDevicePrivateKey.asBytes).toBase64
       val expectJson =
-        s"""{"deviceId":$deviceId,"accountId":"$accountId","segmentId":$segmentId,"signingPrivateKey":"$signingPrivateKeyBase64","devicePrivateKey":"$devicePrivateKeyBase64"}"""
+        s"""{"accountId":"$accountId","segmentId":$segmentId,"signingPrivateKey":"$signingPrivateKeyBase64","devicePrivateKey":"$devicePrivateKeyBase64"}"""
       val result = DeviceContext.fromJsonString(json)
 
       json shouldBe expectJson
       result.getAccountId.getId shouldBe deviceContext.getAccountId.getId
-      result.getDeviceId.getId shouldBe deviceContext.getDeviceId.getId
       result.getDevicePrivateKey.asBytes shouldBe deviceContext.getDevicePrivateKey.asBytes
       result.getSegmentId shouldBe deviceContext.getSegmentId
       result.getSigningPrivateKey.asBytes shouldBe deviceContext.getSigningPrivateKey.asBytes

--- a/tests/version.sbt
+++ b/tests/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.0"
+version in ThisBuild := "0.9.1-SNAPSHOT"

--- a/tests/version.sbt
+++ b/tests/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.3-SNAPSHOT"
+version in ThisBuild := "0.9.0"


### PR DESCRIPTION
Addresses the first part of https://github.com/ironcorelabs/ironoxide-java/issues/62

- Removes `deviceId` from DeviceContext