### PR TITLE
Get rid of the IronSdkAdvanced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "ironoxide-java"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide-java"
-version = "0.9.0"
+version = "0.11.0"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 build = "build.rs"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,33 +26,6 @@ use std::convert::TryInto;
 
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 
-/// Wrap IronOxide to allow namespacing of the advanced operations
-struct IronSdkAdvanced<'a>(&'a IronOxide);
-
-impl<'a> IronSdkAdvanced<'a> {
-    pub fn advanced(ironoxide: &IronOxide) -> IronSdkAdvanced {
-        IronSdkAdvanced(ironoxide)
-    }
-
-    pub fn document_encrypt_unmanaged(
-        &self,
-        data: &[i8],
-        opts: &DocumentEncryptOpts,
-    ) -> Result<DocumentEncryptUnmanagedResult, String> {
-        Ok(self.0.document_encrypt_unmanaged(i8_conv(data), opts)?)
-    }
-
-    pub fn document_decrypt_unmanaged(
-        &self,
-        encrypted_data: &[i8],
-        encrypted_deks: &[i8],
-    ) -> Result<DocumentDecryptUnmanagedResult, String> {
-        Ok(self
-            .0
-            .document_decrypt_unmanaged(i8_conv(encrypted_data), i8_conv(encrypted_deks))?)
-    }
-}
-
 #[derive(Clone)]
 pub struct UserWithKey((UserId, PublicKey));
 impl UserWithKey {
@@ -1042,6 +1015,21 @@ fn group_rotate_private_key(
     Ok(sdk.group_rotate_private_key(group_id)?)
 }
 
+fn advanced_document_encrypt_unmanaged(
+    sdk: &IronOxide,
+    data: &[i8],
+    opts: &DocumentEncryptOpts,
+) -> Result<DocumentEncryptUnmanagedResult, String> {
+    Ok(sdk.document_encrypt_unmanaged(i8_conv(data), opts)?)
+}
+
+fn advanced_document_decrypt_unmanaged(
+    sdk: &IronOxide,
+    encrypted_data: &[i8],
+    encrypted_deks: &[i8],
+) -> Result<DocumentDecryptUnmanagedResult, String> {
+    Ok(sdk.document_decrypt_unmanaged(i8_conv(encrypted_data), i8_conv(encrypted_deks))?)
+}
 mod group_access_edit_result {
     use super::*;
     pub fn succeeded(result: &GroupAccessEditResult) -> Vec<UserId> {

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -802,24 +802,6 @@ class DocumentAccessResult {
     method DocumentAccessChange::errors(&self) -> FailedResult; alias getErrors;
 });
 
-foreigner_class!(
-class IronSdkAdvanced {
-    self_type IronSdkAdvanced<'a>;
-    private constructor = empty;
-    /// Encrypt the provided document bytes. Return the encrypted document encryption keys (EDEKs) instead of creating a document entry in the IronCore webservice.
-    /// 
-    /// @param documentData   bytes of the document to encrypt
-    /// @param encryptOpts    optional document encrypt parameters
-    method IronSdkAdvanced::document_encrypt_unmanaged(&self, documentData: &[i8], encryptOpts: &DocumentEncryptOpts) -> Result<DocumentEncryptUnmanagedResult, String>; alias documentEncryptUnmanaged;
-    /// Decrypt the provided encrypted document with the encrypted document encryption keys (EDEKs).
-    /// 
-    /// @param encryptedData bytes of encrypted document. Should be the same bytes returned from {@link #documentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
-    /// @param encryptedDeks encrypted document encryption keys. Should be the same edeks returned from {@link #documentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
-    /// 
-    /// @return {@link DocumentDecryptResult} includes the id of the provided document as well as the decrypted document bytes
-    method IronSdkAdvanced::document_decrypt_unmanaged(&self, encryptedData: &[i8], encryptedDeks: &[i8]) -> Result<DocumentDecryptUnmanagedResult, String>; alias documentDecryptUnmanaged;
-});
-
 ///
 /// Full SDK Class Structure
 ///
@@ -871,10 +853,6 @@ class IronSdk {
     ///
     /// @return details about the newly created device
     static_method generate_new_device(jwt:&str, password:&str, deviceCreateOptions: &DeviceCreateOpts) -> Result<DeviceAddResult, String>; alias generateNewDevice;
-    /// Access advanced SDK operations.
-    /// 
-    /// @return an instance of the IronSdkAdvanced
-    method IronSdkAdvanced::advanced(&self) -> IronSdkAdvanced<'a>;
     /// Get all the devices for the current user
     ///
     /// @return all devices for the current user, sorted by the device id
@@ -1023,8 +1001,21 @@ class IronSdk {
     /// There's no black magic here! This is accomplished via multi-party computation with the
     /// IronCore webservice.
     /// Note: You must be an admin of the group in order to rotate its private key.
-    /// 
+    ///
     /// @param id id of the group you wish to rotate the private key of
     /// @return The id of the group whose private key got updated and associated metadata
     method group_rotate_private_key(&self, id:&GroupId) -> Result<GroupUpdatePrivateKeyResult, String>; alias groupRotatePrivateKey;
+
+    /// Encrypt the provided document bytes. Return the encrypted document encryption keys (EDEKs) instead of creating a document entry in the IronCore webservice.
+    ///
+    /// @param documentData   bytes of the document to encrypt
+    /// @param encryptOpts    optional document encrypt parameters
+    method advanced_document_encrypt_unmanaged(&self, documentData: &[i8], encryptOpts: &DocumentEncryptOpts) -> Result<DocumentEncryptUnmanagedResult, String>; alias advancedDocumentEncryptUnmanaged;
+    /// Decrypt the provided encrypted document with the encrypted document encryption keys (EDEKs).
+    ///
+    /// @param encryptedData bytes of encrypted document. Should be the same bytes returned from {@link #documentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
+    /// @param encryptedDeks encrypted document encryption keys. Should be the same edeks returned from {@link #documentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
+    ///
+    /// @return {@link DocumentDecryptResult} includes the id of the provided document as well as the decrypted document bytes
+    method advanced_document_decrypt_unmanaged(&self, encryptedData: &[i8], encryptedDeks: &[i8]) -> Result<DocumentDecryptUnmanagedResult, String>; alias advancedDocumentDecryptUnmanaged;
 });

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -1013,8 +1013,8 @@ class IronSdk {
     method advanced_document_encrypt_unmanaged(&self, documentData: &[i8], encryptOpts: &DocumentEncryptOpts) -> Result<DocumentEncryptUnmanagedResult, String>; alias advancedDocumentEncryptUnmanaged;
     /// Decrypt the provided encrypted document with the encrypted document encryption keys (EDEKs).
     ///
-    /// @param encryptedData bytes of encrypted document. Should be the same bytes returned from {@link #documentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
-    /// @param encryptedDeks encrypted document encryption keys. Should be the same edeks returned from {@link #documentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
+    /// @param encryptedData bytes of encrypted document. Should be the same bytes returned from {@link #advancedDocumentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
+    /// @param encryptedDeks encrypted document encryption keys. Should be the same edeks returned from {@link #advancedDocumentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
     ///
     /// @return {@link DocumentDecryptResult} includes the id of the provided document as well as the decrypted document bytes
     method advanced_document_decrypt_unmanaged(&self, encryptedData: &[i8], encryptedDeks: &[i8]) -> Result<DocumentDecryptUnmanagedResult, String>; alias advancedDocumentDecryptUnmanaged;

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -41,6 +41,6 @@ scalacOptions in (Compile, console) ~= {
 }
 scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
 
-javaOptions in Test += s"-Djava.library.path=../target/debug/"
+javaOptions in Test += s"-Djava.library.path=../target/release/"
 fork in Test := true
 envVars in Test := Map("IRONCORE_ENV" -> "stage")

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -41,6 +41,6 @@ scalacOptions in (Compile, console) ~= {
 }
 scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
 
-javaOptions in Test += s"-Djava.library.path=../target/release/"
+javaOptions in Test += s"-Djava.library.path=../target/debug/"
 fork in Test := true
 envVars in Test := Map("IRONCORE_ENV" -> "stage")

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -712,12 +712,12 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     "roundtrip through a user" in {
       val sdk = IronSdk.initialize(createDeviceContext)
       val data: Array[Byte] = List(10, 2, 3).map(_.toByte).toArray
-      val maybeResult = Try(sdk.advanced.documentEncryptUnmanaged(data, new DocumentEncryptOpts())).toEither
+      val maybeResult = Try(sdk.advancedDocumentEncryptUnmanaged(data, new DocumentEncryptOpts())).toEither
       val result = maybeResult.value
       result.getId.getId.length shouldBe 32
 
       val maybeDecrypt =
-        Try(sdk.advanced.documentDecryptUnmanaged(result.getEncryptedData, result.getEncryptedDeks)).toEither
+        Try(sdk.advancedDocumentDecryptUnmanaged(result.getEncryptedData, result.getEncryptedDeks)).toEither
       val decryptedResult = maybeDecrypt.value
 
       decryptedResult.getId.getId shouldBe result.getId.getId
@@ -731,8 +731,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val sdk = IronSdk.initialize(createDeviceContext)
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(
-        sdk.advanced
-          .documentEncryptUnmanaged(
+        sdk.advancedDocumentEncryptUnmanaged(
             data,
             DocumentEncryptOpts.create(null, null, false, Array(), Array(validGroupId), null)
           )
@@ -743,7 +742,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       result.getEncryptedDeks.isEmpty shouldBe false
 
       val maybeDecrypt =
-        Try(sdk.advanced.documentDecryptUnmanaged(result.getEncryptedData, result.getEncryptedDeks)).toEither
+        Try(sdk.advancedDocumentDecryptUnmanaged(result.getEncryptedData, result.getEncryptedDeks)).toEither
       val decryptedResult = maybeDecrypt.value
 
       decryptedResult.getId.getId shouldBe result.getId.getId
@@ -757,8 +756,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val sdk = IronSdk.initialize(createDeviceContext)
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(
-        sdk.advanced
-          .documentEncryptUnmanaged(
+        sdk.advancedDocumentEncryptUnmanaged(
             data,
             DocumentEncryptOpts.create(null, null, true, Array(secondaryTestUserId), Array(), null)
           )
@@ -775,8 +773,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val sdk = IronSdk.initialize(createDeviceContext)
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(
-        sdk.advanced
-          .documentEncryptUnmanaged(
+        sdk.advancedDocumentEncryptUnmanaged(
             data,
             DocumentEncryptOpts.create(
               null,
@@ -807,8 +804,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val notAUser = Try(UserId.validate(java.util.UUID.randomUUID().toString())).toEither.value
       val notAGroup = Try(GroupId.validate(java.util.UUID.randomUUID().toString())).toEither.value
       val maybeResult = Try(
-        sdk.advanced
-          .documentEncryptUnmanaged(
+        sdk.advancedDocumentEncryptUnmanaged(
             data,
             DocumentEncryptOpts.create(null, null, true, Array(notAUser), Array(notAGroup), null)
           )

--- a/tests/version.sbt
+++ b/tests/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.10.1-SNAPSHOT"
+version in ThisBuild := "0.11.0-SNAPSHOT"


### PR DESCRIPTION
As pointed out in #76 - There is an issue with the way this struct is defined. We decided to just move the functions onto the IronSdk class with the prefix `advanced`. 