### PR TITLE
Add timeout and policy cache options to SDK methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "ironoxide-java"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -31,7 +31,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "arrayref"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -77,7 +77,7 @@ name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -111,8 +111,8 @@ dependencies = [
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -129,7 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -153,12 +153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.3.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -275,7 +275,7 @@ name = "curve25519-dalek"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -284,13 +284,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "3.4.0"
+version = "3.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ahash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "qadapt-spin 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -303,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -339,7 +338,7 @@ dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -405,50 +404,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-executor 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures-io"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -459,25 +458,25 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-task"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-util"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -513,7 +512,7 @@ name = "gridiron"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -522,16 +521,16 @@ name = "h2"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -561,9 +560,9 @@ name = "http"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -571,7 +570,7 @@ name = "http-body"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -590,23 +589,23 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -616,10 +615,10 @@ name = "hyper-tls"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -635,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -651,16 +650,16 @@ dependencies = [
 
 [[package]]
 name = "ironoxide"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64-serde 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "dashmap 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dashmap 3.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -673,13 +672,13 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "recrypt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec1 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -691,11 +690,11 @@ dependencies = [
  "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ironoxide 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ironoxide 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=cfd12fb7406f9f2774832c051ce7b4e6c2e193d7)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -708,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -821,10 +820,10 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schannel 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -887,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl"
-version = "0.10.26"
+version = "0.10.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -895,7 +894,7 @@ dependencies = [
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -905,10 +904,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.53"
+version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -936,20 +935,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pin-project"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pin-project-internal 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-internal 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1005,7 +1004,7 @@ name = "protobuf"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1034,14 +1033,9 @@ dependencies = [
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "qadapt-spin"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quick-error"
@@ -1202,7 +1196,7 @@ name = "recrypt"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1224,18 +1218,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1252,13 +1246,13 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1269,10 +1263,10 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1283,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.9"
+version = "0.16.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1307,8 +1301,8 @@ dependencies = [
  "petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smol_str 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1317,11 +1311,8 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "ryu"
@@ -1330,7 +1321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "schannel"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1373,10 +1364,10 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1386,8 +1377,8 @@ name = "serde_urlencoded"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1415,7 +1406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1521,10 +1512,10 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1541,7 +1532,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1549,12 +1540,12 @@ name = "tokio-util"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1593,7 +1584,7 @@ name = "unicode-normalization"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1672,7 +1663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1681,7 +1672,7 @@ name = "wasm-bindgen-backend"
 version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bumpalo 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1826,10 +1817,10 @@ dependencies = [
 
 [metadata]
 "checksum ahash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0989268a37e128d4d7a8028f1c60099430113fdbc70419010601ce51a228e4fe"
-"checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
-"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+"checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "750b1c38a1dfadd108da0f01c08f4cdc7ff1bb39b325f9c82cc972361780a6e1"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
@@ -1842,10 +1833,10 @@ dependencies = [
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-"checksum bumpalo 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb8038c1ddc0a5f73787b130f4cc75151e96ed33e417fde765eb5a81e3532f4"
+"checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38"
+"checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+"checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
@@ -1860,9 +1851,9 @@ dependencies = [
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
-"checksum dashmap 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97fc2bebacc83d7ff26f697f347fa70d4973219f87a4ad2dd3690f4129b157b7"
+"checksum dashmap 3.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7f63d151ae6528220feaae38a4c22e517fd7de0b5abf3c7dd1b61b1dbe1f596b"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-"checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
+"checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 "checksum ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81956bcf7ef761fb4e1d88de3fa181358a0d26cbcb9755b587a08f9119824b86"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
@@ -1877,15 +1868,15 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987"
-"checksum futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86"
-"checksum futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
-"checksum futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
-"checksum futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff"
-"checksum futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
-"checksum futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
-"checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
-"checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
+"checksum futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+"checksum futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+"checksum futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+"checksum futures-executor 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+"checksum futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+"checksum futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+"checksum futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+"checksum futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+"checksum futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
@@ -1898,14 +1889,14 @@ dependencies = [
 "checksum http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-"checksum hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8bf49cfb32edee45d890537d9057d1b02ed55f53b7b6a30bae83a38c9231749e"
+"checksum hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fa1c527bbc634be72aa7ba31e4e4def9bbb020f5416916279b7c705cd838893e"
 "checksum hyper-tls 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
-"checksum indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc"
+"checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum ironoxide 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2599dbbcd7a89e01b55e0419e10388bb6c6ec82773020803b4964587146cb71e"
+"checksum ironoxide 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1d3d5e62a7acfc68969851ca39bc97334addeb47e99874701602846bb91c9fa"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -1927,15 +1918,15 @@ dependencies = [
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-"checksum openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)" = "3a3cc5799d98e1088141b8e01ff760112bbd9f19d850c124500566ca6901a585"
+"checksum openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)" = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-"checksum openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)" = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
+"checksum openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)" = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
-"checksum pin-project 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "75fca1c4ff21f60ca2d37b80d72b63dab823a9d19d3cda3a81d18bc03f0ba8c5"
-"checksum pin-project-internal 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6544cd4e4ecace61075a6ec78074beeef98d58aa9a3d07d053d993b2946a90d6"
+"checksum pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
+"checksum pin-project-internal 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
 "checksum pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
@@ -1947,7 +1938,6 @@ dependencies = [
 "checksum protobuf-codegen 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6456421eecf7fc72905868cd760c3e35848ded3552e480cfe67726ed4dbd8d23"
 "checksum protobuf-codegen-pure 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4a7cb42d5ab6073333be90208ab5ea6ab41c8f6803b35fd773a7572624cc15c9"
 "checksum publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
-"checksum qadapt-spin 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f611c8f8569fbe485c26a15f2fbcc4c1c95577081b361766fe97beece56b16f"
 "checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -1967,25 +1957,25 @@ dependencies = [
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum recrypt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "90e05c800cb7778bb3c7a18769da10f5de729ab00b963246dbf3e170f88f29b6"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87"
-"checksum regex-syntax 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e734e891f5b408a29efbf8309e656876276f49ab6a6ac208600b4419bd893d90"
+"checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
+"checksum regex-syntax 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0e798e19e258bf6c30a304622e3e9ac820e483b06a1857a026e1f109b113fe4"
-"checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
+"checksum ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)" = "741ba1704ae21999c00942f9f5944f801e977f54302af346b596287599ad1862"
 "checksum rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=cfd12fb7406f9f2774832c051ce7b4e6c2e193d7)" = "<none>"
-"checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
+"checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-"checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
+"checksum schannel 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
 "checksum security-framework 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
 "checksum security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
-"checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
+"checksum serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "15913895b61e0be854afd32fd4163fcd2a3df34142cf2cb961b310ce694cbf90"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
+"checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum smol_str 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34836c9a295c62c2ce3514471117c5cb269891e8421b2aafdd910050576c4d8b"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
@@ -1999,7 +1989,7 @@ dependencies = [
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c1fc73332507b971a5010664991a441b5ee0de92017f5a0e8b00fd684573045b"
+"checksum tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
 "checksum tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide-java"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 build = "build.rs"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.8"
-ironoxide = {version = "0.18.0", features = ["blocking"]}
+ironoxide = {version = "0.19.0", features = ["blocking"]}
 chrono = "0.4"
 serde_json = "~1.0"
 
@@ -20,3 +20,9 @@ serde_json = "~1.0"
 env_logger = "0.7"
 rust_swig = { git = "https://github.com/Dushistov/rust_swig.git", rev = "cfd12fb7406f9f2774832c051ce7b4e6c2e193d7"}
 bindgen = "0.52"
+
+[profile.dev]
+opt-level = 0
+
+[profile.dev.package."*"]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,3 @@ serde_json = "~1.0"
 env_logger = "0.7"
 rust_swig = { git = "https://github.com/Dushistov/rust_swig.git", rev = "cfd12fb7406f9f2774832c051ce7b4e6c2e193d7"}
 bindgen = "0.52"
-
-[profile.dev]
-opt-level = 0
-
-[profile.dev.package."*"]
-opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -855,14 +855,14 @@ mod ironoxide_config {
     ) -> IronOxideConfig {
         IronOxideConfig {
             policy_caching: policy_caching.clone(),
-            sdk_operation_timeout: sdk_operation_timeout.cloned(),
+            sdk_operation_timeout: sdk_operation_timeout.copied(),
         }
     }
 }
 
 //Java SDK wrapper functions for doing unnatural things with the JNI.
 fn user_verify(jwt: &str, timeout: Option<&Duration>) -> Result<Option<UserResult>, String> {
-    Ok(IronOxide::user_verify(jwt, timeout.cloned())?)
+    Ok(IronOxide::user_verify(jwt, timeout.copied())?)
 }
 fn user_create(
     jwt: &str,
@@ -874,7 +874,7 @@ fn user_create(
         jwt,
         password,
         opts,
-        timeout.cloned(),
+        timeout.copied(),
     )?)
 }
 fn initialize(init: &DeviceContext, config: &IronOxideConfig) -> Result<IronOxide, String> {
@@ -886,7 +886,7 @@ fn initialize_and_rotate(
     config: &IronOxideConfig,
     timeout: Option<&Duration>,
 ) -> Result<IronOxide, String> {
-    let rotate_timeout = timeout.cloned().or(config.sdk_operation_timeout);
+    let rotate_timeout = timeout.copied().or(config.sdk_operation_timeout);
     Ok(
         match ironoxide::blocking::initialize_check_rotation(init, config)? {
             InitAndRotationCheck::RotationNeeded(ironoxide, rotation) => {
@@ -907,7 +907,7 @@ fn generate_new_device(
         jwt,
         password,
         opts,
-        timeout.cloned(),
+        timeout.copied(),
     )?)
 }
 fn user_list_devices(sdk: &IronOxide) -> Result<UserDeviceListResult, String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod jni_c_header;
 use ironoxide::{
     blocking::BlockingIronOxide as IronOxide,
+    config::{IronOxideConfig, PolicyCachingConfig},
     document::{
         advanced::{DocumentDecryptUnmanagedResult, DocumentEncryptUnmanagedResult},
         AssociationType, DocAccessEditErr, DocumentAccessResult, DocumentDecryptResult,
@@ -21,7 +22,7 @@ use ironoxide::{
     PublicKey,
 };
 use serde_json;
-use std::convert::TryInto;
+use std::{convert::TryInto, time::Duration};
 
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 
@@ -839,25 +840,75 @@ mod group_create_opts {
     }
 }
 
+mod policy_caching_config {
+    use super::*;
+    pub fn create(max_entries: usize) -> PolicyCachingConfig {
+        PolicyCachingConfig { max_entries }
+    }
+}
+
+mod ironoxide_config {
+    use super::*;
+    pub fn create(
+        policy_caching: &PolicyCachingConfig,
+        sdk_operation_timeout: Option<&Timeout>,
+    ) -> IronOxideConfig {
+        IronOxideConfig {
+            policy_caching: policy_caching.clone(),
+            sdk_operation_timeout: sdk_operation_timeout.map(Timeout::into_duration),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Timeout {
+    millis: u64,
+}
+impl Timeout {
+    pub fn from_millis(millis: u64) -> Timeout {
+        Timeout { millis }
+    }
+    pub fn from_secs(secs: u32) -> Timeout {
+        Timeout {
+            millis: (secs * 1000) as u64,
+        }
+    }
+    fn into_duration(&self) -> Duration {
+        Duration::from_millis(self.millis)
+    }
+}
+
 //Java SDK wrapper functions for doing unnatural things with the JNI.
-fn user_verify(jwt: &str) -> Result<Option<UserResult>, String> {
-    Ok(IronOxide::user_verify(jwt)?)
+fn user_verify(jwt: &str, timeout: Option<&Timeout>) -> Result<Option<UserResult>, String> {
+    let maybe_duration = timeout.map(Timeout::into_duration);
+    Ok(IronOxide::user_verify(jwt, maybe_duration)?)
 }
 fn user_create(
     jwt: &str,
     password: &str,
     opts: &UserCreateOpts,
+    timeout: Option<&Timeout>,
 ) -> Result<UserCreateResult, String> {
-    Ok(IronOxide::user_create(jwt, password, opts)?)
+    let maybe_duration = timeout.map(Timeout::into_duration);
+    Ok(IronOxide::user_create(jwt, password, opts, maybe_duration)?)
 }
-fn initialize(init: &DeviceContext) -> Result<IronOxide, String> {
-    Ok(ironoxide::blocking::initialize(init)?)
+fn initialize(init: &DeviceContext, config: &IronOxideConfig) -> Result<IronOxide, String> {
+    Ok(ironoxide::blocking::initialize(init, config)?)
 }
-fn initialize_and_rotate(init: &DeviceContext, password: &str) -> Result<IronOxide, String> {
+fn initialize_and_rotate(
+    init: &DeviceContext,
+    password: &str,
+    config: &IronOxideConfig,
+    timeout: Option<&Timeout>,
+) -> Result<IronOxide, String> {
+    let rotate_timeout = match timeout {
+        Some(t) => Some(t.into_duration()),
+        None => config.sdk_operation_timeout,
+    };
     Ok(
-        match ironoxide::blocking::initialize_check_rotation(init)? {
+        match ironoxide::blocking::initialize_check_rotation(init, config)? {
             InitAndRotationCheck::RotationNeeded(ironoxide, rotation) => {
-                ironoxide.rotate_all(&rotation, password)?;
+                ironoxide.rotate_all(&rotation, password, rotate_timeout)?;
                 ironoxide
             }
             InitAndRotationCheck::NoRotationNeeded(ironoxide) => ironoxide,
@@ -868,8 +919,15 @@ fn generate_new_device(
     jwt: &str,
     password: &str,
     opts: &DeviceCreateOpts,
+    timeout: Option<&Timeout>,
 ) -> Result<DeviceAddResult, String> {
-    Ok(IronOxide::generate_new_device(jwt, password, opts)?)
+    let maybe_duration = timeout.map(Timeout::into_duration);
+    Ok(IronOxide::generate_new_device(
+        jwt,
+        password,
+        opts,
+        maybe_duration,
+    )?)
 }
 fn user_list_devices(sdk: &IronOxide) -> Result<UserDeviceListResult, String> {
     Ok(sdk.user_list_devices()?)

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -812,16 +812,16 @@ foreigner_class!(
 foreigner_class!(
     class IronOxideConfig{
         self_type IronOxideConfig;
-        constructor ironoxide_config::create(policy_caching: &PolicyCachingConfig, sdk_operation_timeout: Option<&Timeout>) -> IronOxideConfig;
+        constructor ironoxide_config::create(policy_caching: &PolicyCachingConfig, sdk_operation_timeout: Option<&Duration>) -> IronOxideConfig;
     }
 );
 
 foreigner_class!(
-    class Timeout{
-        self_type Timeout;
+    class Duration{
+        self_type Duration;
         private constructor = empty;
-        static_method Timeout::from_millis(millis: u64) -> Timeout;
-        static_method Timeout::from_secs(secs: u32) -> Timeout;
+        static_method Duration::from_millis(millis: u64) -> Duration;
+        static_method Duration::from_secs(secs: u64) -> Duration;
     }
 );
 
@@ -841,7 +841,7 @@ class IronOxide {
     /// @param jwt      valid IronCore JWT
     /// @param timeout  timeout for this operation or `null` for no timeout
     /// @return option of whether the user's account record exists in the IronCore system or not. Error if the request couldn't be made.
-    static_method user_verify(jwt:&str, timeout: Option<&Timeout>) -> Result<Option<UserResult>, String>; alias userVerify;
+    static_method user_verify(jwt:&str, timeout: Option<&Duration>) -> Result<Option<UserResult>, String>; alias userVerify;
     /// Create a new user within the IronCore system.
     ///
     /// @param jwt       valid IronCore or Auth0 JWT
@@ -850,7 +850,7 @@ class IronOxide {
     /// @param timeout   timeout for this operation or `null` for no timeout
     /// @return see {@link UserCreateResult}. For most use cases, the public key can be discarded as IronCore escrows your user's keys.
     ///         The escrowed keys are unlocked by the provided password.
-    static_method user_create(jwt:&str, password:&str, options:&UserCreateOpts, timeout: Option<&Timeout>) -> Result<UserCreateResult, String>; alias userCreate;
+    static_method user_create(jwt:&str, password:&str, options:&UserCreateOpts, timeout: Option<&Duration>) -> Result<UserCreateResult, String>; alias userCreate;
     /// Initialize IronOxide with a device. Verifies that the provided user/segment exists and the provided device
     /// keys are valid and exist for the provided account.
     /// 
@@ -871,7 +871,7 @@ class IronOxide {
     ///                  from the SDK-wide timeout as it is expected that this operation might take significantly
     ///                  longer than other operations. If `null`, defaults to the SDK operation timeout in `config`.
     /// @return an instance of the IronOxide
-    static_method initialize_and_rotate(init: &DeviceContext, password: &str, config: &IronOxideConfig, timeout: Option<&Timeout>) -> Result<IronOxide, String>; alias initializeAndRotate;
+    static_method initialize_and_rotate(init: &DeviceContext, password: &str, config: &IronOxideConfig, timeout: Option<&Duration>) -> Result<IronOxide, String>; alias initializeAndRotate;
     /// Generates a new device for the user specified in the signed JWT.
     ///
     /// This will result in a new transform key (from the user's master private key to the new device's public key)
@@ -882,7 +882,7 @@ class IronOxide {
     /// @param deviceCreateOptions  optional values, like device name
     /// @param timeout              timeout for this operation or `null` for no timeout
     /// @return details about the newly created device
-    static_method generate_new_device(jwt:&str, password:&str, deviceCreateOptions: &DeviceCreateOpts, timeout: Option<&Timeout>) -> Result<DeviceAddResult, String>; alias generateNewDevice;
+    static_method generate_new_device(jwt:&str, password:&str, deviceCreateOptions: &DeviceCreateOpts, timeout: Option<&Duration>) -> Result<DeviceAddResult, String>; alias generateNewDevice;
     /// Get all the devices for the current user
     ///
     /// @return all devices for the current user, sorted by the device id

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -1,7 +1,7 @@
-use crate::jni_c_header::*;
 use crate::{
     document_access_change_result::{DocumentAccessChange, FailedResult, SucceededResult},
     document_decrypt_unmanaged_result::UserOrGroupJ,
+    jni_c_header::*,
 };
 use chrono::{DateTime, Utc};
 
@@ -442,7 +442,7 @@ class UserDevice {
 
 foreigner_class!(class DeviceCreateOpts {
     self_type DeviceCreateOpts;
-    //Construct the DeviceCreateOpts with None for name.
+    //Construct the DeviceCreateOpts with `null` for name.
     constructor DeviceCreateOpts::default() -> DeviceCreateOpts;
     static_method device_create_opts::create(_:Option<DeviceName>) -> DeviceCreateOpts;
 });
@@ -653,7 +653,7 @@ foreigner_class!(
 class DocumentEncryptOpts {
     self_type DocumentEncryptOpts;
     constructor DocumentEncryptOpts::default() -> DocumentEncryptOpts;
-    /// @param id            unique id of a document. If none, the server will assign an id
+    /// @param id            unique id of a document. If `null`, the server will assign an id
     /// @param name          human readable name of the document. Does not need to be unique
     /// @param grantToAuthor Flag determining whether to encrypt to the calling user or not. If set to false at least one value must be present in the `grant` lists.
     /// @param userGrants    list of user ids that will be granted access to the document
@@ -802,6 +802,29 @@ class DocumentAccessResult {
     method DocumentAccessChange::errors(&self) -> FailedResult; alias getErrors;
 });
 
+foreigner_class!(
+    class PolicyCachingConfig{
+        self_type PolicyCachingConfig;
+        constructor policy_caching_config::create(max_entries: usize) -> PolicyCachingConfig;
+    }
+);
+
+foreigner_class!(
+    class IronOxideConfig{
+        self_type IronOxideConfig;
+        constructor ironoxide_config::create(policy_caching: &PolicyCachingConfig, sdk_operation_timeout: Option<&Timeout>) -> IronOxideConfig;
+    }
+);
+
+foreigner_class!(
+    class Timeout{
+        self_type Timeout;
+        private constructor = empty;
+        static_method Timeout::from_millis(millis: u64) -> Timeout;
+        static_method Timeout::from_secs(secs: u32) -> Timeout;
+    }
+);
+
 ///
 /// Full SDK Class Structure
 ///
@@ -810,49 +833,56 @@ foreigner_class!(
 /// Struct that is used to make authenticated requests to the IronCore API. Instantiated with the details
 /// of an accounts various ids, device, and signing keys. Once instantiated all operations will be
 /// performed in the context of the account provided.
-class IronSdk {
+class IronOxide {
     self_type IronOxide;
     private constructor = empty;
     /// Verify a user given a JWT for their user record.
     ///
-    /// @param jwt valid IronCore JWT
+    /// @param jwt      valid IronCore JWT
+    /// @param timeout  timeout for this operation or `null` for no timeout
     /// @return option of whether the user's account record exists in the IronCore system or not. Error if the request couldn't be made.
-    static_method user_verify(jwt:&str) -> Result<Option<UserResult>, String>; alias userVerify;
-   /// Create a new user within the IronCore system.
-   ///
-   /// @param jwt       valid IronCore or Auth0 JWT
-   /// @param password  password used to encrypt and escrow the user's private master key
-   /// @param options   see {@link UserCreateOpts}. Use `new UserCreateOpts()` for defaults
-   /// @return see {@link UserCreateResult}. For most use cases, the public key can be discarded as IronCore escrows your user's keys.
-   ///         The escrowed keys are unlocked by the provided password.
-    static_method user_create(jwt:&str, password:&str, options:&UserCreateOpts) -> Result<UserCreateResult, String>; alias userCreate;
-    /// Initialize IronSdk with a device. Verifies that the provided user/segment exists and the provided device
+    static_method user_verify(jwt:&str, timeout: Option<&Timeout>) -> Result<Option<UserResult>, String>; alias userVerify;
+    /// Create a new user within the IronCore system.
+    ///
+    /// @param jwt       valid IronCore or Auth0 JWT
+    /// @param password  password used to encrypt and escrow the user's private master key
+    /// @param options   see {@link UserCreateOpts}. Use `new UserCreateOpts()` for defaults
+    /// @param timeout   timeout for this operation or `null` for no timeout
+    /// @return see {@link UserCreateResult}. For most use cases, the public key can be discarded as IronCore escrows your user's keys.
+    ///         The escrowed keys are unlocked by the provided password.
+    static_method user_create(jwt:&str, password:&str, options:&UserCreateOpts, timeout: Option<&Timeout>) -> Result<UserCreateResult, String>; alias userCreate;
+    /// Initialize IronOxide with a device. Verifies that the provided user/segment exists and the provided device
     /// keys are valid and exist for the provided account.
     /// 
-    /// @param init device context used to initialize the IronSdk with a set of device keys
+    /// @param init    device context used to initialize the IronOxide with a set of device keys
+    /// @param config  configuration for policy caching and SDK operation timeouts
     /// @throws java.lang.Exception if the provided `DeviceContext` is invalid
-    /// @return an instance of the IronSdk
-    static_method initialize(init:&DeviceContext) -> Result<IronOxide, String>;
-    /// Initialize IronSdk with a device. Verifies that the provided user/segment exists and the provided device
+    /// @return an instance of the IronOxide
+    static_method initialize(init:&DeviceContext, config: &IronOxideConfig) -> Result<IronOxide, String>;
+    /// Initialize IronOxide with a device. Verifies that the provided user/segment exists and the provided device
     /// keys are valid and exist for the provided account.
     /// After initialization, checks whether the calling user's private key needs rotation and rotates it 
     /// if necessary, then does the same for each group the user is an admin of.
     /// 
-    /// @param init device context used to initialize the IronSdk with a set of device keys
-    /// @param password password used to encrypt and escrow the user's private master key
-    /// @return an instance of the IronSdk
-    static_method initialize_and_rotate(init: &DeviceContext, password: &str) -> Result<IronOxide, String>; alias initializeAndRotate;
+    /// @param init      device context used to initialize the IronOxide with a set of device keys
+    /// @param password  password used to encrypt and escrow the user's private master key
+    /// @param config    configuration for policy caching and SDK operation timeouts
+    /// @param timeout   timeout used only for the potential call to rotate_all. This is a separate timeout 
+    ///                  from the SDK-wide timeout as it is expected that this operation might take significantly
+    ///                  longer than other operations. If `null`, defaults to the SDK operation timeout in `config`.
+    /// @return an instance of the IronOxide
+    static_method initialize_and_rotate(init: &DeviceContext, password: &str, config: &IronOxideConfig, timeout: Option<&Timeout>) -> Result<IronOxide, String>; alias initializeAndRotate;
     /// Generates a new device for the user specified in the signed JWT.
     ///
     /// This will result in a new transform key (from the user's master private key to the new device's public key)
     /// being generated and stored with the IronCore Service.
     ///
-    /// @param jwt                 valid IronCore JWT
-    /// @param password            password used to encrypt and escrow the user's private key
-    /// @param deviceCreateOptions optional values, like device name
-    ///
+    /// @param jwt                  valid IronCore JWT
+    /// @param password             password used to encrypt and escrow the user's private key
+    /// @param deviceCreateOptions  optional values, like device name
+    /// @param timeout              timeout for this operation or `null` for no timeout
     /// @return details about the newly created device
-    static_method generate_new_device(jwt:&str, password:&str, deviceCreateOptions: &DeviceCreateOpts) -> Result<DeviceAddResult, String>; alias generateNewDevice;
+    static_method generate_new_device(jwt:&str, password:&str, deviceCreateOptions: &DeviceCreateOpts, timeout: Option<&Timeout>) -> Result<DeviceAddResult, String>; alias generateNewDevice;
     /// Get all the devices for the current user
     ///
     /// @return all devices for the current user, sorted by the device id
@@ -861,24 +891,21 @@ class IronSdk {
     /// IronCore system to determine of they can be added to groups or have documents shared with them.AsMut
     ///
     /// @param users list of user IDs to check
-    ///
     /// @return map from user ID to users public key. Only users who have public keys will be returned in the map
     method user_get_public_key(&self, users: Vec<UserId>) -> Result<Vec<UserWithKey>, String>; alias userGetPublicKey;
     /// Delete a user device.
     ///
-    /// If deleting the currently signed in device (None for `deviceId`), the sdk will need to be
-    /// reinitialized with `IronSdk.initialize()` before further use.
+    /// If deleting the currently signed in device (`null` for `deviceId`), the sdk will need to be
+    /// reinitialized with `IronOxide.initialize()` before further use.
     ///
     /// @param deviceId id of the device to delete. If `null`, delete the currently signed in device {@link #userListDevices()} to get ids
-    ///
-    /// @return id of deleted device or IronSdkErr
+    /// @return id of deleted device
     method user_delete_device(&self, deviceId: Option<DeviceId>) -> Result<DeviceId, String>; alias userDeleteDevice;
     /// Rotate the current user's private key, but leave the public key the same.
     /// There's no black magic here! This is accomplished via multi-party computation with the
     /// IronCore webservice.
     ///
     /// @param password password to unlock the current user's master private key
-    ///
     /// @return The (encrypted) updated private key and associated metadata
     method user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult, String>; alias userRotatePrivateKey;
     /// List all of the documents that the current user is able to decrypt.
@@ -888,20 +915,18 @@ class IronSdk {
     /// Get the metadata for a specific document given its id.
     ///
     /// @param id unique id of the document to retrieve
-    ///
     /// @return {@link DocumentMetadataResult} with details about the requested document.
     method document_get_metadata(&self, id :&DocumentId) -> Result<DocumentMetadataResult, String>; alias documentGetMetadata;
     /// Attempt to parse the document id out of an encrypted document.
     ///
     /// @param encryptedDocument encrypted document bytes
-    ///
     /// @throws java.lang.Exception if provided encrypted document has no header
     /// @return extracted id
     method document_get_id_from_bytes(&self, encryptedDocument:&[i8]) -> Result<DocumentId, String>; alias documentGetIdFromBytes;
     /// Encrypt the provided document bytes.
     ///
-    /// @param documentData   bytes of the document to encrypt
-    /// @param encryptOpts    optional document encrypt parameters
+    /// @param documentData  bytes of the document to encrypt
+    /// @param encryptOpts   optional document encrypt parameters
     method document_encrypt(&self, documentData: &[i8], encryptOpts: &DocumentEncryptOpts) -> Result<DocumentEncryptResult, String>; alias documentEncrypt;
     /// Update the encrypted content of an existing document. Persists any existing access to other users and groups.
     ///
@@ -911,32 +936,28 @@ class IronSdk {
     /// Decrypts the provided encrypted document and returns details about the document as well as its decrypted bytes.
     ///
     /// @param encryptedDocument bytes of encrypted document. Should be the same bytes returned from {@link #documentEncrypt(byte[], DocumentEncryptOpts)}
-    ///
     /// @return {@link DocumentDecryptResult} includes metadata about the provided document as well as the decrypted document bytes
     method document_decrypt(&self, encryptedDocument: &[i8]) -> Result<DocumentDecryptResult, String>; alias documentDecrypt;
     /// Update a document name to a new value or clear its value.
     ///
-    /// @param id      id of the document to update
-    /// @param name    new name for the document. Provide a {@link DocumentName} to update to a new name or `null` to clear the name field
-    ///
+    /// @param id    id of the document to update
+    /// @param name  new name for the document. Provide a {@link DocumentName} to update to a new name or `null` to clear the name field
     /// @return metadata about the document that was updated.
     method document_update_name(&self, id: &DocumentId, name: Option<DocumentName>) -> Result<DocumentMetadataResult, String>; alias documentUpdateName;
     /// Grant access to a document. Recipients of document access can be either users or groups.
     ///
     /// @param documentId   id of the document whose access is is being modified
-    /// @param userGrants  list of user grants
-    /// @param groupGrants list of group grants
-    ///
+    /// @param userGrants   list of user grants
+    /// @param groupGrants  list of group grants
     /// @throws java.lang.Exception the request failed either on the client or the server rejected the whole request
     /// @return each individual grant to a user/group succeeded or failed
     method document_grant_access(&self, documentId: &DocumentId, userGrants: Vec<UserId>, groupGrants: Vec<GroupId>)
         -> Result<DocumentAccessResult, String>; alias documentGrantAccess;
     /// Revoke access from a document. Revocation of document access can be either users or groups.
     ///
-    /// @param documentId     id of the document whose access is is being modified
-    /// @param userRevokes    list of user revokes
-    /// @param groupRevokes   list of group revokes
-    ///
+    /// @param documentId    id of the document whose access is is being modified
+    /// @param userRevokes   list of user revokes
+    /// @param groupRevokes  list of group revokes
     /// @throws java.lang.Exception the request failed either on the client or the server rejected the whole request
     /// @return each individual revoke from a user/group either succeeded or failed
     method document_revoke_access(&self, documentId: &DocumentId, userRevokes: Vec<UserId>, groupRevokes: Vec<GroupId>)
@@ -948,7 +969,6 @@ class IronSdk {
     /// Get the full metadata for a specific group given its ID.
     ///
     /// @param id unique id of the group to retrieve
-    ///
     /// @return details about the requested group
     method group_get_metadata(&self, id:&GroupId) -> Result<GroupGetResult, String>; alias groupGetMetadata;
     /// Create a group. The creating user will become a group admin.
@@ -957,44 +977,38 @@ class IronSdk {
     method group_create(&self, groupCreateOpts: &GroupCreateOpts) -> Result<GroupCreateResult, String>; alias groupCreate;
     /// Update a group name to a new value or clear its value.
     ///
-    /// @param id      id of the group to update
-    /// @param name    new name for the group. Provide a {@link GroupName} to update to a new name or `null` to clear the name field
-    ///
+    /// @param id    id of the group to update
+    /// @param name  new name for the group. Provide a {@link GroupName} to update to a new name or `null` to clear the name field
     /// @return metadata about the group that was updated
     method group_update_name(&self, id: &GroupId, name: Option<GroupName>) -> Result<GroupMetaResult, String>; alias groupUpdateName;
     /// Delete the identified group.
     ///
     /// @param id unique id of group
-    ///
     /// @throws java.lang.Exception if it wasn't able to delete the group
     /// @return the deleted group id
     method group_delete(&self, id: &GroupId) -> Result<GroupId, String>; alias groupDelete;
     /// Add the users as members of a group.
     ///
-    /// @param id      id of the group to add members to
-    /// @param users   the list of users thet will be added to the group as members
-    /// 
+    /// @param id     id of the group to add members to
+    /// @param users  the list of users thet will be added to the group as members
     /// @return all the users that were added and all the users that were not added with the reason they were not
     method group_add_members(&self, id:&GroupId, users:Vec<UserId>) -> Result<GroupAccessEditResult, String>; alias groupAddMembers;
     /// Remove a list of users as members from the group.
     ///
-    /// @param id          id of the group to remove members from
-    /// @param userRevokes list of user ids to remove as members
-    ///
+    /// @param id           id of the group to remove members from
+    /// @param userRevokes  list of user ids to remove as members
     /// @return list of users that were removed and the users that failed to be removed with the reason they were not
     method group_remove_members(&self, id:&GroupId, userRevokes: Vec<UserId>) -> Result<GroupAccessEditResult, String>; alias groupRemoveMembers;
     /// Add the users as admins of a group.
     ///
-    /// @param id      id of the group to add admins to
-    /// @param users   the list of users that will be added to the group as admins
-    /// 
+    /// @param id     id of the group to add admins to
+    /// @param users  the list of users that will be added to the group as admins
     /// @return all the users that were added and the users that were not added with the reason they were not
     method group_add_admins(&self, id: &GroupId, users: Vec<UserId>) -> Result<GroupAccessEditResult, String>; alias groupAddAdmins;
     /// Remove a list of users as admins from the group.
     ///
-    /// @param id          id of the group
-    /// @param userRevokes list of user ids to remove as admins
-    ///
+    /// @param id           id of the group
+    /// @param userRevokes  list of user ids to remove as admins
     /// @return list of users that were removed and the users that failed to be removed with the reason they were not
     method group_remove_admins(&self, id:&GroupId, userRevokes: Vec<UserId>) -> Result<GroupAccessEditResult, String>; alias groupRemoveAdmins;
     /// Rotate the provided group's private key, but leave the public key the same.
@@ -1008,14 +1022,13 @@ class IronSdk {
 
     /// Encrypt the provided document bytes. Return the encrypted document encryption keys (EDEKs) instead of creating a document entry in the IronCore webservice.
     ///
-    /// @param documentData   bytes of the document to encrypt
-    /// @param encryptOpts    optional document encrypt parameters
+    /// @param documentData  bytes of the document to encrypt
+    /// @param encryptOpts   optional document encrypt parameters
     method advanced_document_encrypt_unmanaged(&self, documentData: &[i8], encryptOpts: &DocumentEncryptOpts) -> Result<DocumentEncryptUnmanagedResult, String>; alias advancedDocumentEncryptUnmanaged;
     /// Decrypt the provided encrypted document with the encrypted document encryption keys (EDEKs).
     ///
-    /// @param encryptedData bytes of encrypted document. Should be the same bytes returned from {@link #advancedDocumentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
-    /// @param encryptedDeks encrypted document encryption keys. Should be the same edeks returned from {@link #advancedDocumentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
-    ///
+    /// @param encryptedData  bytes of encrypted document. Should be the same bytes returned from {@link #advancedDocumentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
+    /// @param encryptedDeks  encrypted document encryption keys. Should be the same edeks returned from {@link #advancedDocumentEncryptUnmanaged(byte[], DocumentEncryptOpts)}
     /// @return {@link DocumentDecryptResult} includes the id of the provided document as well as the decrypted document bytes
     method advanced_document_decrypt_unmanaged(&self, encryptedData: &[i8], encryptedDeks: &[i8]) -> Result<DocumentDecryptUnmanagedResult, String>; alias advancedDocumentDecryptUnmanaged;
 });

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -806,12 +806,14 @@ foreigner_class!(
     class PolicyCachingConfig{
         self_type PolicyCachingConfig;
         constructor policy_caching_config::create(max_entries: usize) -> PolicyCachingConfig;
+        constructor PolicyCachingConfig::default() -> PolicyCachingConfig;
     }
 );
 
 foreigner_class!(
     class IronOxideConfig{
         self_type IronOxideConfig;
+        constructor IronOxideConfig::default() -> IronOxideConfig;
         constructor ironoxide_config::create(policy_caching: &PolicyCachingConfig, sdk_operation_timeout: Option<&Duration>) -> IronOxideConfig;
     }
 );

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -28,9 +28,9 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   val defaultPolicyCaching = new PolicyCachingConfig(100)
 
-  val shortTimeout = Timeout.from_millis(5)
-  val defaultTimeout = Timeout.from_secs(30)
-  val longTimeout = Timeout.from_secs(30)
+  val shortTimeout = Duration.from_millis(5)
+  val defaultTimeout = Duration.from_secs(30)
+  val longTimeout = Duration.from_secs(30)
 
   val shortConfig = new IronOxideConfig(defaultPolicyCaching, shortTimeout)
   val defaultConfig = new IronOxideConfig(defaultPolicyCaching, defaultTimeout)

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -26,14 +26,14 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
   var validGroupId: GroupId = null
   var validDocumentId: DocumentId = null
 
-  val defaultPolicyCaching = new PolicyCachingConfig(100)
+  val defaultPolicyCaching = new PolicyCachingConfig()
 
   val shortTimeout = Duration.from_millis(5)
   val defaultTimeout = Duration.from_secs(30)
   val longTimeout = Duration.from_secs(30)
 
   val shortConfig = new IronOxideConfig(defaultPolicyCaching, shortTimeout)
-  val defaultConfig = new IronOxideConfig(defaultPolicyCaching, defaultTimeout)
+  val defaultConfig = new IronOxideConfig()
 
   /**
     * Convenience function to create a new DeviceContext instance from the stored off components we need. Takes the

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -26,6 +26,15 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
   var validGroupId: GroupId = null
   var validDocumentId: DocumentId = null
 
+  val defaultPolicyCaching = new PolicyCachingConfig(100)
+
+  val shortTimeout = Timeout.from_millis(5)
+  val defaultTimeout = Timeout.from_secs(30)
+  val longTimeout = Timeout.from_secs(30)
+
+  val shortConfig = new IronOxideConfig(defaultPolicyCaching, shortTimeout)
+  val defaultConfig = new IronOxideConfig(defaultPolicyCaching, defaultTimeout)
+
   /**
     * Convenience function to create a new DeviceContext instance from the stored off components we need. Takes the
     * users account ID, segment ID, private device key bytes, and signing key bytes and returns a new DeviceContext
@@ -52,7 +61,8 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
   "User Create" should {
     "successfully create a new user" in {
       val jwt = JwtHelper.generateValidJwt(primaryTestUserId.getId)
-      val resp = Try(IronSdk.userCreate(jwt, primaryTestUserPassword, UserCreateOpts.create(true))).toEither
+      val resp =
+        Try(IronOxide.userCreate(jwt, primaryTestUserPassword, UserCreateOpts.create(true), defaultTimeout)).toEither
       val createResult = resp.value
 
       createResult.getUserPublicKey.asBytes should have length 64
@@ -61,18 +71,26 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
     "successfully create a 2nd new user" in {
       val jwt = JwtHelper.generateValidJwt(secondaryTestUserId.getId)
-      val resp = Try(IronSdk.userCreate(jwt, secondaryTestUserPassword, UserCreateOpts.create(true))).toEither
+      val resp = Try(IronOxide.userCreate(jwt, secondaryTestUserPassword, UserCreateOpts.create(true), null)).toEither
       val createResult = resp.value
 
       createResult.getUserPublicKey.asBytes should have length 64
       createResult.getNeedsRotation shouldBe true
+    }
+
+    "fail with short timeout" in {
+      val jwt = JwtHelper.generateValidJwt(primaryTestUserId.getId)
+      val resp =
+        Try(IronOxide.userCreate(jwt, primaryTestUserPassword, UserCreateOpts.create(true), shortTimeout)).toEither
+
+      resp.isLeft shouldBe true
     }
   }
 
   "User Verify" should {
     "fails for user that does not exist" in {
       val jwt = JwtHelper.generateValidJwt("not a real user")
-      val resp = Try(IronSdk.userVerify(jwt)).toEither
+      val resp = Try(IronOxide.userVerify(jwt, null)).toEither
 
       val verifyResult = resp.value
 
@@ -81,7 +99,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
     "successfully verify existing user" in {
       val jwt = JwtHelper.generateValidJwt(primaryTestUserId.getId)
-      val resp = Try(IronSdk.userVerify(jwt)).toEither
+      val resp = Try(IronOxide.userVerify(jwt, defaultTimeout)).toEither
 
       val verifyResult = resp.value
 
@@ -96,7 +114,8 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
   "User Device Generate" should {
     "fail for bad user password" in {
       val jwt = JwtHelper.generateValidJwt(primaryTestUserId.getId)
-      val expectedException = Try(IronSdk.generateNewDevice(jwt, "BAD PASSWORD", new DeviceCreateOpts())).toEither
+      val expectedException =
+        Try(IronOxide.generateNewDevice(jwt, "BAD PASSWORD", new DeviceCreateOpts(), null)).toEither
       expectedException.leftValue.getMessage should include("AesError")
     }
 
@@ -105,10 +124,10 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val jwt2 = JwtHelper.generateValidJwt(secondaryTestUserId.getId)
       val deviceName = Try(DeviceName.validate("myDevice")).toEither.value
       val newDeviceResult = Try(
-        IronSdk.generateNewDevice(jwt, primaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone))
+        IronOxide.generateNewDevice(jwt, primaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone), null)
       ).toEither.value
       val secondDeviceResult = Try(
-        IronSdk.generateNewDevice(jwt2, secondaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone))
+        IronOxide.generateNewDevice(jwt2, secondaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone), null)
       ).toEither.value
 
       newDeviceResult.getCreated shouldBe newDeviceResult.getLastUpdated
@@ -129,12 +148,19 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       newDeviceResult.getDevicePrivateKey.asBytes should have size 32
       newDeviceResult.getAccountId shouldBe primaryTestUserId
 
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val deviceList = sdk.userListDevices.getResult
       deviceList.length shouldBe 1
       deviceList.head.getId.getId shouldBe a[java.lang.Long]
       deviceList.head.getName.isPresent shouldBe true
       deviceList.head.getName.get shouldBe deviceName
+    }
+  }
+
+  "Initialize" should {
+    "fail with short timeout" in {
+      val maybeSdk = Try(IronOxide.initialize(createDeviceContext, shortConfig)).toEither
+      maybeSdk.isLeft shouldBe true
     }
   }
 
@@ -144,7 +170,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val deviceName = DeviceName.validate("device")
       val deviceContext =
         new DeviceContext(
-          IronSdk.generateNewDevice(jwt, secondaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone))
+          IronOxide.generateNewDevice(jwt, secondaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone), null)
         )
       val json = deviceContext.toJsonString
       val accountId = deviceContext.getAccountId.getId
@@ -177,13 +203,14 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val jwt = JwtHelper.generateValidJwt(primaryTestUserId.getId)
 
       // a second device
-      Try(IronSdk.generateNewDevice(jwt, primaryTestUserPassword, DeviceCreateOpts.create(null))).toEither
+      Try(IronOxide.generateNewDevice(jwt, primaryTestUserPassword, DeviceCreateOpts.create(null), null)).toEither
 
       // a third device
-      val deviceResp2 = Try(IronSdk.generateNewDevice(jwt, primaryTestUserPassword, new DeviceCreateOpts())).toEither
+      val deviceResp2 =
+        Try(IronOxide.generateNewDevice(jwt, primaryTestUserPassword, new DeviceCreateOpts(), null)).toEither
       val dev3 = new DeviceContext(deviceResp2.value)
 
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val deviceList = Try(sdk.userListDevices).toEither.value.getResult
 
       deviceList.length shouldBe 3 // We have the primary device as well as secondary and tertiary devices generated above
@@ -207,7 +234,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "Delete valid device" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val result = Try(sdk.userDeleteDevice(secondaryDeviceId.clone)).toEither
 
       result.value shouldBe secondaryDeviceId
@@ -219,7 +246,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "Error for other user's device" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val deviceId = Try(DeviceId.validate(42)).toEither.value
       val result = Try(sdk.userDeleteDevice(deviceId)).toEither
 
@@ -227,11 +254,11 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "Delete current device" in {
-      val sdk = IronSdk.initialize(tertiaryDevice)
+      val sdk = IronOxide.initialize(tertiaryDevice, defaultConfig)
       sdk.userDeleteDevice(null)
 
       // Need to use a new SDK object since I just deleted the device of the old one
-      val sdk2 = IronSdk.initialize(createDeviceContext)
+      val sdk2 = IronOxide.initialize(createDeviceContext, defaultConfig)
       // confirm that the third device was deleted. Only primary should remain.
       val deviceList = sdk2.userListDevices().getResult()
       deviceList.length shouldBe 1
@@ -240,14 +267,14 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "User Get PublicKey" should {
     "Return empty for ids that don't exist" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val badUserId = Try(UserId.validate("not-a-user")).toEither.value
       val result = Try(sdk.userGetPublicKey(List(badUserId).toArray)).toEither
       result.value.toList shouldBe Nil
     }
 
     "Return both for ids that do exist" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val result = Try(sdk.userGetPublicKey(List(primaryTestUserId, secondaryTestUserId).toArray)).toEither
       //Sort the values just to make sure the assertion doesn't fail due to ordering being off.
       result.value.toList
@@ -258,7 +285,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Group Create" should {
     "Create valid group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val groupName = Try(GroupName.validate("a name")).toEither.value
       val groupCreateResult =
         sdk.groupCreate(GroupCreateOpts.create(null, groupName.clone, true, true, null, Array(), Array(), true))
@@ -278,7 +305,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       validGroupId = groupCreateResult.getId
     }
     "Create default group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val groupCreateResult = sdk.groupCreate(new GroupCreateOpts())
 
       groupCreateResult.getId.getId.length shouldBe 32 //gooid
@@ -289,7 +316,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       groupCreateResult.getNeedsRotation.get.getBoolean shouldBe false
     }
     "Create group without members" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val groupName = Try(GroupName.validate("no member")).toEither.value
       val groupCreateResult =
         sdk.groupCreate(
@@ -310,18 +337,18 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Group Private Key Rotate" should {
     "Successfully rotate a valid group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val rotateResult = sdk.groupRotatePrivateKey(validGroupId)
       rotateResult.getNeedsRotation shouldBe false
       rotateResult.getId shouldBe validGroupId
     }
     "Fail for non-admin" in {
-      val sdk = IronSdk.initialize(createSecondaryDeviceContext)
+      val sdk = IronOxide.initialize(createSecondaryDeviceContext, defaultConfig)
       val rotateResult = Try(sdk.groupRotatePrivateKey(validGroupId)).toEither
       rotateResult.isLeft shouldBe true
     }
     "Fail for invalid group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val rotateResult = Try(sdk.groupRotatePrivateKey(GroupId.validate("7584"))).toEither
       rotateResult.isLeft shouldBe true
     }
@@ -329,7 +356,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Group List" should {
     "Return previously created group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
 
       val groupResult = sdk.groupList().getResult()
 
@@ -346,7 +373,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Group Get Metadata" should {
     "Return an error when retrieving a group that doesnt exist" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val groupId = Try(GroupId.validate("not-a-group=ID-that-exists=")).toEither.value
       val resp = Try(sdk.groupGetMetadata(groupId)).toEither
       resp.leftValue.getMessage should include("404")
@@ -354,7 +381,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "Succeed for valid group ID" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val resp = Try(sdk.groupGetMetadata(validGroupId)).toEither
       val group = resp.value
 
@@ -376,7 +403,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "succeed for a non-member" in {
-      val nonMemberSdk = IronSdk.initialize(createSecondaryDeviceContext)
+      val nonMemberSdk = IronOxide.initialize(createSecondaryDeviceContext, defaultConfig)
       val resp = Try(nonMemberSdk.groupGetMetadata(validGroupId)).toEither
       val group = resp.value
 
@@ -396,9 +423,9 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     "provide public key to users out of the group" in {
       val jwt = JwtHelper.generateValidJwt(secondaryTestUserId.getId)
       val secondaryUserDevice =
-        Try(IronSdk.generateNewDevice(jwt, secondaryTestUserPassword, new DeviceCreateOpts())).toEither.value
+        Try(IronOxide.generateNewDevice(jwt, secondaryTestUserPassword, new DeviceCreateOpts(), null)).toEither.value
 
-      val sdk = IronSdk.initialize(new DeviceContext(secondaryUserDevice))
+      val sdk = IronOxide.initialize(new DeviceContext(secondaryUserDevice), defaultConfig)
       val resp = Try(sdk.groupGetMetadata(validGroupId)).toEither
       val group = resp.value
 
@@ -417,7 +444,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Group update name" should {
     "change name of group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val newGroupName = Try(GroupName.validate("new name")).toEither.value
 
       val updateResp = Try(sdk.groupUpdateName(validGroupId, newGroupName.clone)).toEither
@@ -433,7 +460,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "clear out the group name" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
 
       val clearResp = Try(sdk.groupUpdateName(validGroupId, null)).toEither
       val clearedGroup = clearResp.value
@@ -444,7 +471,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Group remove member" should {
     "remove current user from group and fail for unknown user" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val randoUser = Try(UserId.validate("not-a-real-user")).toEither.value
       val removeMemberResp =
         Try(sdk.groupRemoveMembers(validGroupId, List(primaryTestUserId, randoUser).toArray)).toEither
@@ -461,7 +488,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Group add member" should {
     "succeed and add user back to group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
 
       val addMemberResp =
         Try(sdk.groupAddMembers(validGroupId, List(primaryTestUserId, secondaryTestUserId).toArray)).toEither
@@ -473,7 +500,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "fail to add a user who is already in the group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
 
       val addMemberResp = Try(sdk.groupAddMembers(validGroupId, List(primaryTestUserId).toArray)).toEither
 
@@ -486,7 +513,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
   // Now that the secondary user has been added as a member, re-verify the metadata it gets back
   "Group Get Metadata" should {
     "succeed for a member" in {
-      val memberSdk = IronSdk.initialize(createSecondaryDeviceContext)
+      val memberSdk = IronOxide.initialize(createSecondaryDeviceContext, defaultConfig)
       val resp = Try(memberSdk.groupGetMetadata(validGroupId)).toEither
       val group = resp.value
 
@@ -510,7 +537,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Group add admin" should {
     "succeed and add secondary user as an admin" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
 
       val addAdminResp = Try(sdk.groupAddAdmins(validGroupId, List(secondaryTestUserId).toArray)).toEither
 
@@ -521,7 +548,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "fail to add a user who is already in an admin of the group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
 
       val addAdminsResp = Try(sdk.groupAddMembers(validGroupId, List(primaryTestUserId).toArray)).toEither
 
@@ -533,7 +560,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Group remove admin" should {
     "Succeed at removing a secondary user" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
 
       val removeMemberResp = Try(sdk.groupRemoveAdmins(validGroupId, List(secondaryTestUserId).toArray)).toEither
 
@@ -546,7 +573,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Document encrypt/decrypt" should {
     "succeed for good name and data" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val docName = Try(DocumentName.validate("name")).toEither.value
       val maybeResult =
@@ -557,7 +584,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "roundtrip for single level transform for no name and good data" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val data: Array[Byte] = List(10, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(sdk.documentEncrypt(data, new DocumentEncryptOpts())).toEither
       val result = maybeResult.value
@@ -579,7 +606,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "grant to specified users" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(
         sdk.documentEncrypt(
@@ -595,7 +622,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "grant to specified groups and INTERNAL/PII policy" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(
         sdk.documentEncrypt(
@@ -624,7 +651,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "return failures for bad users and groups" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val notAUser = Try(UserId.validate(java.util.UUID.randomUUID().toString())).toEither.value
       val notAGroup = Try(GroupId.validate(java.util.UUID.randomUUID().toString())).toEither.value
@@ -650,7 +677,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "User Private Key Rotation" should {
     "successfully rotate a private key for good password" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val originalPublicKey = sdk.userGetPublicKey(Array(primaryTestUserId))(0).getPublicKey.asBytes
       val data: Array[Byte] = List(10, 2, 3).map(_.toByte).toArray
       val encryptResult = Try(sdk.documentEncrypt(data, new DocumentEncryptOpts())).toEither.value
@@ -670,18 +697,18 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val jwt = JwtHelper.generateValidJwt(primaryTestUserId.getId)
       val deviceName = Try(DeviceName.validate("newdevice")).toEither.value
       val newDeviceResult = Try(
-        IronSdk.generateNewDevice(jwt, primaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone))
+        IronOxide.generateNewDevice(jwt, primaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone), null)
       ).toEither.value
       newDeviceResult.getAccountId.getId shouldBe primaryTestUserId.getId
     }
     "fail for wrong password" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val maybeRotationResult = Try(sdk.userRotatePrivateKey("wrong password")).toEither
 
       maybeRotationResult.leftValue.getMessage should include("AesError")
     }
     "rotate with initializeAndRotate for second user" in {
-      val sdk = IronSdk.initialize(createSecondaryDeviceContext)
+      val sdk = IronOxide.initialize(createSecondaryDeviceContext, defaultConfig)
       val groupName = Try(GroupName.validate("a name")).toEither.value
       val groupCreateResult =
         sdk.groupCreate(GroupCreateOpts.create(null, groupName.clone, true, true, null, Array(), Array(), true))
@@ -689,15 +716,21 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val data: Array[Byte] = List(3, 1, 4).map(_.toByte).toArray
       val encryptResult = Try(sdk.documentEncrypt(data, new DocumentEncryptOpts())).toEither.value
       val decryptResult = Try(sdk.documentDecrypt(encryptResult.getEncryptedData)).toEither.value
+      // try to rotate everything within 5ms and fail
+      val failedSdk = Try(
+        IronOxide
+          .initializeAndRotate(createSecondaryDeviceContext, secondaryTestUserPassword, defaultConfig, shortTimeout)
+      ).toEither
+      failedSdk.isLeft shouldBe true
       // rotate the private key using initializeAndRotate, but ignore the duplicate sdk returned
-      IronSdk.initializeAndRotate(createSecondaryDeviceContext, secondaryTestUserPassword)
+      IronOxide.initializeAndRotate(createSecondaryDeviceContext, secondaryTestUserPassword, defaultConfig, longTimeout)
       val rotatedPublicKey = sdk.userGetPublicKey(Array(secondaryTestUserId))(0).getPublicKey.asBytes
       val rotatedDecryptResult = Try(sdk.documentDecrypt(encryptResult.getEncryptedData)).toEither.value
       val groupGetResult = sdk.groupGetMetadata(groupCreateResult.getId)
 
       // need to call user verify to check the needsRotation
       val jwt = JwtHelper.generateValidJwt(secondaryTestUserId.getId)
-      val resp = Try(IronSdk.userVerify(jwt)).toEither.value.get
+      val resp = Try(IronOxide.userVerify(jwt, null)).toEither.value.get
 
       rotatedPublicKey shouldBe originalPublicKey
       resp.getNeedsRotation shouldBe false
@@ -706,11 +739,12 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       rotatedDecryptResult.getName shouldBe decryptResult.getName
       groupGetResult.getNeedsRotation.get.getBoolean shouldBe false
     }
+
   }
 
   "Document unmanaged encrypt/decrypt" should {
     "roundtrip through a user" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val data: Array[Byte] = List(10, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(sdk.advancedDocumentEncryptUnmanaged(data, new DocumentEncryptOpts())).toEither
       val result = maybeResult.value
@@ -728,7 +762,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "roundtrip through a group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(
         sdk.advancedDocumentEncryptUnmanaged(
@@ -753,7 +787,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "grant to specified users" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(
         sdk.advancedDocumentEncryptUnmanaged(
@@ -770,7 +804,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "grant to specified groups and INTERNAL/PII policy" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(
         sdk.advancedDocumentEncryptUnmanaged(
@@ -799,7 +833,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "return failures for bad users and groups" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val notAUser = Try(UserId.validate(java.util.UUID.randomUUID().toString())).toEither.value
       val notAGroup = Try(GroupId.validate(java.util.UUID.randomUUID().toString())).toEither.value
@@ -829,7 +863,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Document update name" should {
     "successfully update to new name" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val newDocName = Try(DocumentName.validate("new name")).toEither.value
 
       val maybeUpdate = Try(sdk.documentUpdateName(validDocumentId, newDocName.clone)).toEither
@@ -841,7 +875,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "successfully clear name" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
 
       val maybeUpdate = Try(sdk.documentUpdateName(validDocumentId, null)).toEither
 
@@ -853,14 +887,14 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Document List" should {
     "Return previously created documents" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       sdk.documentList.getResult should have length 6
     }
   }
 
   "Document Get Metadata" should {
     "Return an error when retrieving a document that doesnt exist" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val docID = Try(DocumentId.validate("not-a-document-ID-that-exists=/")).toEither.value
       val resp = Try(sdk.documentGetMetadata(docID)).toEither
       resp.leftValue.getMessage should include("404")
@@ -868,7 +902,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "Return expected details about document" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val maybeDoc = Try(sdk.documentGetMetadata(validDocumentId)).toEither
 
       val doc = maybeDoc.value
@@ -884,7 +918,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Document update bytes" should {
     "Update encrypted bytes with existing AES key but still be decryptable" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
 
       val newData: Array[Byte] = List(10, 20, 30).map(_.toByte).toArray
       val maybeResult = Try(sdk.documentUpdateBytes(validDocumentId, newData)).toEither
@@ -903,7 +937,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Document grant access" should {
     "succeed for good doc and user/group and fail for bad user/group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
 
       val badUserId = Try(UserId.validate("bad-user-id")).toEither.value
       val badGroupId = Try(GroupId.validate("bad-group-id")).toEither.value
@@ -927,7 +961,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Document revoke access" should {
     "succeed for good doc and user/group and fail for bad user/group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val badUserId = Try(UserId.validate("bad-user-id")).toEither.value
       val badGroupId = Try(GroupId.validate("bad-group-id")).toEither.value
 
@@ -951,14 +985,14 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
   // group delete needs to be close to the bottom of these tests as previous tests depend on it still being available
   "Group Delete" should {
     "successfully delete valid group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       sdk.groupDelete(validGroupId) shouldBe validGroupId
 
       sdk.groupList.getResult.length shouldBe 2
     }
 
     "fail to delete non-existent group" in {
-      val sdk = IronSdk.initialize(createDeviceContext)
+      val sdk = IronOxide.initialize(createDeviceContext, defaultConfig)
       val badGroupId = Try(GroupId.validate("bad-group-id")).toEither.value
       val resp = Try(sdk.groupDelete(badGroupId)).toEither
       resp.leftValue.getMessage should include("404")

--- a/tests/src/test/scala/ironrust/UserCreateFailureTest.scala
+++ b/tests/src/test/scala/ironrust/UserCreateFailureTest.scala
@@ -6,7 +6,7 @@ import scala.util.Try
 class UserCreateFailureTest extends DudeSuite {
   "userCreate" should {
     "return error for fixed jwt" in {
-      val badResponseTry = Try(IronSdk.userCreate("foo", "bar", UserCreateOpts.create(true))).toEither
+      val badResponseTry = Try(IronOxide.userCreate("foo", "bar", UserCreateOpts.create(true), null)).toEither
       badResponseTry.leftValue.getMessage should include(
         """must be valid ascii and be formatted correctly"""
       )
@@ -14,7 +14,7 @@ class UserCreateFailureTest extends DudeSuite {
     "return error for outdated jwt" in {
       val jwt =
         "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NTA3NzE4MjMsImlhdCI6MTU1MDc3MTcwMywia2lkIjo1NTEsInBpZCI6MTAxMiwic2lkIjoidGVzdC1zZWdtZW50Iiwic3ViIjoiYTAzYjhlNTYtMTVkMi00Y2Y3LTk0MWYtYzYwMWU1NzUxNjNiIn0.vlqt0da5ltA2dYEK9i_pfRxPd3K2uexnkbAbzmbjW65XNcWlBOIbcdmmQLnSIZkRyTORD3DLXOIPYbGlApaTCR5WbaR3oPiSsR9IqdhgMEZxCcarqGg7b_zzwTP98fDcALGZNGsJL1hIrl3EEXdPoYjsOJ5LMF1H57NZiteBDAsm1zfXgOgCtvCdt7PQFSCpM5GyE3und9VnEgjtcQ6HAZYdutqjI79vaTnjt2A1X38pbHcnfvSanzJoeU3szwtBiVlB3cfXbROvBC7Kz8KvbWJzImJcJiRT-KyI4kk3l8wAs2FUjSRco8AQ1nIX21QHlRI0vVr_vdOd_pTXOUU51g"
-      val resp = Try(IronSdk.userCreate(jwt, "foo", UserCreateOpts.create(true))).toEither
+      val resp = Try(IronOxide.userCreate(jwt, "foo", UserCreateOpts.create(true), null)).toEither
       resp.leftValue.getMessage should include(
         """ServerError { message: "\'jwt ey"""
       )

--- a/tests/src/test/scala/ironrust/UserVerifyFailureTest.scala
+++ b/tests/src/test/scala/ironrust/UserVerifyFailureTest.scala
@@ -6,7 +6,7 @@ import scala.util.Try
 class UserVerifyFailureTest extends DudeSuite {
   "userVerify" should {
     "return error for fixed jwt" in {
-      val badResponseTry = Try(IronSdk.userVerify("foo"))
+      val badResponseTry = Try(IronOxide.userVerify("foo", null))
       badResponseTry.isFailure shouldBe true
       badResponseTry.failed.get.getMessage should include(
         "must be valid ascii and be formatted correctly"
@@ -15,7 +15,7 @@ class UserVerifyFailureTest extends DudeSuite {
     "return error for outdated jwt" in {
       val jwt =
         "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NTA3NzE4MjMsImlhdCI6MTU1MDc3MTcwMywia2lkIjo1NTEsInBpZCI6MTAxMiwic2lkIjoidGVzdC1zZWdtZW50Iiwic3ViIjoiYTAzYjhlNTYtMTVkMi00Y2Y3LTk0MWYtYzYwMWU1NzUxNjNiIn0.vlqt0da5ltA2dYEK9i_pfRxPd3K2uexnkbAbzmbjW65XNcWlBOIbcdmmQLnSIZkRyTORD3DLXOIPYbGlApaTCR5WbaR3oPiSsR9IqdhgMEZxCcarqGg7b_zzwTP98fDcALGZNGsJL1hIrl3EEXdPoYjsOJ5LMF1H57NZiteBDAsm1zfXgOgCtvCdt7PQFSCpM5GyE3und9VnEgjtcQ6HAZYdutqjI79vaTnjt2A1X38pbHcnfvSanzJoeU3szwtBiVlB3cfXbROvBC7Kz8KvbWJzImJcJiRT-KyI4kk3l8wAs2FUjSRco8AQ1nIX21QHlRI0vVr_vdOd_pTXOUU51g"
-      val resp = Try(IronSdk.userVerify(jwt))
+      val resp = Try(IronOxide.userVerify(jwt, null))
       resp.isFailure shouldBe true
       resp.failed.get.getMessage should include(
         "was an invalid authorization token"


### PR DESCRIPTION
- Add `timeout` as a parameter to `user_create()`, `user_verify()`, and `generate_new_device()`.
  - `timeout` is an `Option<&Duration>`. `Duration` can be made with `from_millis()` and `from_secs()`.
- Add `config` as a parameter to `initialize()`
  - `config` is an `IronOxideConfig`, made from a `PolicyCachingConfig` and an `Option<&Duration>`
- `initialize_and_rotate()` is a special case that takes both a `config` and a `timeout`. The `config.sdk_operations_timeout` is used for almost all timeouts. `timeout` is used for the `rotate_all()` call, since it could take longer than other calls.
- Matching our changes in `ironoxide-scala`, rename `IronSdk` to `IronOxide`.