### PR TITLE
Override .equals and .hashCode for all classes

### DIFF
--- a/.travis_scripts/cross-test.sh
+++ b/.travis_scripts/cross-test.sh
@@ -7,6 +7,7 @@ set -x
 
 "${JAVA_HOME}/bin/java" -version
 
+ulimit -n 10000
 cargo fmt -- --check
 cargo b
 pushd tests && ~/bin/sbt test && popd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,8 +655,8 @@ dependencies = [
 
 [[package]]
 name = "ironoxide"
-version = "0.19.1"
-source = "git+https://github.com/IronCoreLabs/ironoxide?branch=58-public-derives#f4aca37a3e1c4270ccca9b5e24f39ba1567fd717"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,7 +666,7 @@ dependencies = [
  "dashmap 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.2 (git+https://github.com/rust-itertools/itertools?rev=c83cc48ffe39b96b7c6797b7b31752e840b373bb)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -676,7 +676,7 @@ dependencies = [
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "recrypt 0.9.2 (git+https://github.com/IronCoreLabs/recrypt-rs?branch=hash_eq_all_types)",
+ "recrypt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -695,8 +695,8 @@ dependencies = [
  "bindgen 0.53.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ironoxide 0.19.1 (git+https://github.com/IronCoreLabs/ironoxide?branch=58-public-derives)",
- "itertools 0.8.2 (git+https://github.com/rust-itertools/itertools?rev=c83cc48ffe39b96b7c6797b7b31752e840b373bb)",
+ "ironoxide 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=cfd12fb7406f9f2774832c051ce7b4e6c2e193d7)",
@@ -705,8 +705,8 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
-source = "git+https://github.com/rust-itertools/itertools?rev=c83cc48ffe39b96b7c6797b7b31752e840b373bb#c83cc48ffe39b96b7c6797b7b31752e840b373bb"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1215,8 +1215,8 @@ dependencies = [
 
 [[package]]
 name = "recrypt"
-version = "0.9.2"
-source = "git+https://github.com/IronCoreLabs/recrypt-rs?branch=hash_eq_all_types#52194933d5bcc6219b6e8c0c2d332430f35e3d8d"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1901,8 +1901,8 @@ dependencies = [
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum ironoxide 0.19.1 (git+https://github.com/IronCoreLabs/ironoxide?branch=58-public-derives)" = "<none>"
-"checksum itertools 0.8.2 (git+https://github.com/rust-itertools/itertools?rev=c83cc48ffe39b96b7c6797b7b31752e840b373bb)" = "<none>"
+"checksum ironoxide 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8d06f114d04ce2edc0940ee0714f31319405d1b4dcd2502175e9d197fa24531c"
+"checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum js-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -1964,7 +1964,7 @@ dependencies = [
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum recrypt 0.9.2 (git+https://github.com/IronCoreLabs/recrypt-rs?branch=hash_eq_all_types)" = "<none>"
+"checksum recrypt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "19747180239c937ee8dcdc52e1b703361cd792ab32aaa8e864890f8f73af2ba3"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 "checksum regex-syntax 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "1132f845907680735a84409c3bebc64d1364a5683ffbce899550cd09d5eaefc1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,10 +10,10 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -47,9 +47,9 @@ name = "async-trait"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -57,8 +57,8 @@ name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.52.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -109,7 +109,7 @@ dependencies = [
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -204,7 +204,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -262,7 +262,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "3.4.3"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ahash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -344,10 +344,10 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -451,9 +451,9 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -477,7 +477,7 @@ dependencies = [
  "futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -498,7 +498,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -530,7 +530,7 @@ dependencies = [
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -544,10 +544,10 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -605,7 +605,7 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -618,7 +618,7 @@ dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -645,20 +645,20 @@ name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ironoxide"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/IronCoreLabs/ironoxide?branch=58-public-derives#90659a1608aa7368f1d2394e233e15df4be1b471"
 dependencies = [
  "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64-serde 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "dashmap 3.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dashmap 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -671,14 +671,14 @@ dependencies = [
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "recrypt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "recrypt 0.9.2 (git+https://github.com/IronCoreLabs/recrypt-rs?branch=hash_eq_all_types)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec1 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -687,15 +687,15 @@ dependencies = [
 name = "ironoxide-java"
 version = "0.12.0"
 dependencies = [
- "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.53.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ironoxide 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ironoxide 0.19.0 (git+https://github.com/IronCoreLabs/ironoxide?branch=58-public-derives)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=cfd12fb7406f9f2774832c051ce7b4e6c2e193d7)",
- "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -740,7 +740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -767,7 +767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.3.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -794,7 +794,7 @@ dependencies = [
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -819,7 +819,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -836,7 +836,7 @@ version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -850,7 +850,7 @@ name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -876,8 +876,8 @@ name = "num_cpus"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -894,7 +894,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -910,7 +910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -952,9 +952,9 @@ name = "pin-project-internal"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -982,9 +982,9 @@ name = "proc-macro-hack"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -994,7 +994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1030,7 +1030,7 @@ name = "publicsuffix"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1048,7 +1048,7 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1057,7 +1057,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1075,7 +1075,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1149,7 +1149,7 @@ name = "rand_jitter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1161,7 +1161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1195,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "recrypt"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/IronCoreLabs/recrypt-rs?branch=hash_eq_all_types#8c7a57fa96854c6899d8e9f9c0a93b18f5b25386"
 dependencies = [
  "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1222,8 +1222,8 @@ name = "regex"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1264,10 +1264,10 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1283,7 +1283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1300,13 +1300,13 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smol_str 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1336,7 +1336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1358,14 +1358,14 @@ name = "serde_derive"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1444,9 +1444,9 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1456,10 +1456,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1470,7 +1470,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1506,21 +1506,21 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1533,7 +1533,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1546,7 +1546,7 @@ dependencies = [
  "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1664,7 +1664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1676,9 +1676,9 @@ dependencies = [
  "bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1707,9 +1707,9 @@ name = "wasm-bindgen-macro-support"
 version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1727,9 +1727,9 @@ dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1759,7 +1759,7 @@ name = "which"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [metadata]
 "checksum ahash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0989268a37e128d4d7a8028f1c60099430113fdbc70419010601ce51a228e4fe"
-"checksum aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
+"checksum aho-corasick 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d5e63fd144e18ba274ae7095c0197a870a7b9468abc801dd62f190d80817d2ec"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
@@ -1830,7 +1830,7 @@ dependencies = [
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum base64-serde 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1dcbb80c1f9f58fad55c19aa86b330f2960079e9fe76a3f61c803d2ac492f900"
-"checksum bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1c85344eb535a31b62f0af37be84441ba9e7f0f4111eb0530f43d15e513fe57"
+"checksum bindgen 0.53.1 (registry+https://github.com/rust-lang/crates.io-index)" = "99de13bb6361e01e493b3db7928085dcc474b7ba4f5481818e53a89d76b8393f"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
@@ -1852,14 +1852,14 @@ dependencies = [
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
-"checksum dashmap 3.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7f63d151ae6528220feaae38a4c22e517fd7de0b5abf3c7dd1b61b1dbe1f596b"
+"checksum dashmap 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "93b8a57df1b6a3f0a96df85297d506a871b31252df23f969b9837ccb5d07455c"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 "checksum ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81956bcf7ef761fb4e1d88de3fa181358a0d26cbcb9755b587a08f9119824b86"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-"checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
+"checksum error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
@@ -1884,7 +1884,7 @@ dependencies = [
 "checksum gridiron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "155a2cd35b9d8a8e4b7c9ac380e94acafdb948f3d284942b1d41312371d39c54"
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
+"checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 "checksum http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
@@ -1895,18 +1895,18 @@ dependencies = [
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum ironoxide 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1d3d5e62a7acfc68969851ca39bc97334addeb47e99874701602846bb91c9fa"
+"checksum ironoxide 0.19.0 (git+https://github.com/IronCoreLabs/ironoxide?branch=58-public-derives)" = "<none>"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
-"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+"checksum libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)" = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
+"checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
@@ -1934,7 +1934,7 @@ dependencies = [
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
-"checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+"checksum proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 "checksum protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6686ddd96a8dbe2687b5f2a687b2cfb520854010ec480f2d74c32e7c9873d3c5"
 "checksum protobuf-codegen 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6456421eecf7fc72905868cd760c3e35848ded3552e480cfe67726ed4dbd8d23"
 "checksum protobuf-codegen-pure 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4a7cb42d5ab6073333be90208ab5ea6ab41c8f6803b35fd773a7572624cc15c9"
@@ -1956,12 +1956,12 @@ dependencies = [
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum recrypt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "90e05c800cb7778bb3c7a18769da10f5de729ab00b963246dbf3e170f88f29b6"
+"checksum recrypt 0.9.2 (git+https://github.com/IronCoreLabs/recrypt-rs?branch=hash_eq_all_types)" = "<none>"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 "checksum regex-syntax 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0e798e19e258bf6c30a304622e3e9ac820e483b06a1857a026e1f109b113fe4"
+"checksum reqwest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9f62f24514117d09a8fc74b803d3d65faa27cea1c7378fb12b0d002913f3831"
 "checksum ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)" = "741ba1704ae21999c00942f9f5944f801e977f54302af346b596287599ad1862"
 "checksum rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=cfd12fb7406f9f2774832c051ce7b4e6c2e193d7)" = "<none>"
 "checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
@@ -1971,7 +1971,7 @@ dependencies = [
 "checksum security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
-"checksum serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "15913895b61e0be854afd32fd4163fcd2a3df34142cf2cb961b310ce694cbf90"
+"checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
@@ -1984,13 +1984,13 @@ dependencies = [
 "checksum strum 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "530efb820d53b712f4e347916c5e7ed20deb76a4f0457943b3182fb889b06d2c"
 "checksum strum_macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6e163a520367c465f59e0a61a23cfae3b10b6546d78b6f672a382be79f7110"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
-"checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+"checksum syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
+"checksum tokio 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "b34bee1facdc352fba10c9c58b654e6ecb6a2250167772bf86071f7c5f2f5061"
 "checksum tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,6 +693,7 @@ dependencies = [
  "ironoxide 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_swig 0.5.0-pre (git+https://github.com/Dushistov/rust_swig.git?rev=cfd12fb7406f9f2774832c051ce7b4e6c2e193d7)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde_json = "~1.0"
 env_logger = "0.7"
 rust_swig = { git = "https://github.com/Dushistov/rust_swig.git", rev = "cfd12fb7406f9f2774832c051ce7b4e6c2e193d7"}
 bindgen = "0.52"
+regex = "~1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 log = "0.4"
-# itertools 0.8.2++ - remove on next release
-itertools = {git = "https://github.com/rust-itertools/itertools", rev = "c83cc48ffe39b96b7c6797b7b31752e840b373bb"}
-ironoxide = {git = "https://github.com/IronCoreLabs/ironoxide", branch="58-public-derives", features = ["blocking"]}
+itertools = "0.9.0"
+ironoxide = {version = "0.20.0", features = ["blocking"]}
 chrono = "0.4"
 serde_json = "~1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.8"
-ironoxide = {version = "0.19.0", features = ["blocking"]}
+ironoxide = {git = "https://github.com/IronCoreLabs/ironoxide", branch="58-public-derives", features = ["blocking"]}
 chrono = "0.4"
 serde_json = "~1.0"
 
 [build-dependencies]
 env_logger = "0.7"
 rust_swig = { git = "https://github.com/Dushistov/rust_swig.git", rev = "cfd12fb7406f9f2774832c051ce7b4e6c2e193d7"}
-bindgen = "0.52"
+bindgen = "0.53"
 regex = "~1.3"

--- a/build.rs
+++ b/build.rs
@@ -39,15 +39,16 @@ fn main() {
 
     let now = Instant::now();
     let gen_path = Path::new(&out_dir).join("lib.rs");
-    rust_swig_expand(Path::new("src/lib.rs.in"), &gen_path);
+    let lib_rs_out = out_dir + "lib.rs.out";
+    expand_equality_macro(&lib_rs_out);
+    rust_swig_expand(Path::new(&lib_rs_out), &gen_path);
     let expand_time = now.elapsed();
     println!(
         "rust swig expand time: {}",
         expand_time.as_secs() as f64 + (expand_time.subsec_nanos() as f64) / 1_000_000_000.
     );
-    println!("cargo:rerun-if-changed=src");
-    //rebuild if user removes generated code
-    println!("cargo:rerun-if-changed={}", gen_path.display());
+    println!("cargo:rerun-if-changed=src/lib.rs.in");
+    println!("cargo:rerun-if-changed=src/lib.rs");
 }
 
 fn search_file_in_directory<P: AsRef<Path>>(dirs: &[P], file: &str) -> Result<PathBuf, ()> {
@@ -87,7 +88,9 @@ fn rust_swig_expand(from: &Path, out: &Path) {
         get_java_codegen_output_directory(),
         "com.ironcorelabs.sdk".into(),
     )))
-    .merge_type_map("chrono_support", include_str!("src/chrono-include.rs"));
+    .merge_type_map("chrono_support", include_str!("src/chrono-include.rs"))
+    .rustfmt_bindings(true)
+    .remove_not_generated_files_from_output_directory(true); //remove outdated *.java files
     swig_gen.expand("rust_swig_test_jni", from, out);
 }
 
@@ -101,4 +104,27 @@ fn get_java_codegen_output_directory() -> PathBuf {
             .expect("Couldn't create codegen output directory at java/com/ironcorelabs/sdk.");
     }
     path.to_path_buf()
+}
+
+fn expand_equality_macro(out: &str) {
+    let file =
+        std::fs::read_to_string("src/lib.rs.in").expect("unable to read source file lib.rs.in");
+    let re = regex::Regex::new(r"pre_build_generate_equality (.*);")
+        .expect("unable to parse regex expression");
+    let replaced = re
+        .replace_all(
+            &file,
+            r##"private fn eq(&self, o: &$1) -> bool; alias rustEq;
+            foreign_code r#"
+            public boolean equals(Object obj) {
+                if(obj instanceof $1){
+                    $1 other = ($1) obj;
+                    return other.rustEq(this);
+                }
+            return false;
+        }
+        "#;"##,
+        )
+        .to_string();
+    std::fs::write(out, replaced).expect("unable to output file");
 }

--- a/build.rs
+++ b/build.rs
@@ -39,9 +39,11 @@ fn main() {
 
     let now = Instant::now();
     let gen_path = Path::new(&out_dir).join("lib.rs");
-    let lib_rs_out = out_dir + "lib.rs.out";
-    expand_equality_macro(&lib_rs_out);
-    rust_swig_expand(Path::new(&lib_rs_out), &gen_path);
+    let icl_expanded_lib_rs = out_dir + "icl-expanded-lib.rs.in";
+    // Just before rust_swig expands "lib.rs.in", we do our own expansion
+    // This takes in "lib.rs.in" and outputs "icl-expanded-lib.rs.in", which is then fed to rust_swig.
+    expand_equality_macro(&icl_expanded_lib_rs);
+    rust_swig_expand(Path::new(&icl_expanded_lib_rs), &gen_path);
     let expand_time = now.elapsed();
     println!(
         "rust swig expand time: {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,24 @@ use ironoxide::{
     DeviceAddResult, DeviceContext, DeviceSigningKeyPair, InitAndRotationCheck, PrivateKey,
     PublicKey,
 };
-use std::{convert::TryInto, time::Duration};
+use std::{
+    collections::hash_map::DefaultHasher,
+    convert::TryInto,
+    hash::{Hash, Hasher},
+    time::Duration,
+};
 
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));
+
+pub fn hash<T: Hash>(t: &T) -> i16 {
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    s.finish() as i16
+}
+
+pub fn eq<T: PartialEq>(t: &T, other: &T) -> bool {
+    t.eq(other)
+}
 
 #[derive(Clone)]
 pub struct UserWithKey((UserId, PublicKey));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub fn eq<T: PartialEq>(t: &T, other: &T) -> bool {
     t.eq(other)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct UserWithKey((UserId, PublicKey));
 impl UserWithKey {
     pub fn user(&self) -> UserId {
@@ -53,6 +53,7 @@ impl UserWithKey {
 }
 
 // This was created because Option<bool> cannot be converted to Java
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct NullableBoolean(bool);
 impl NullableBoolean {
     pub fn boolean(&self) -> bool {
@@ -558,14 +559,15 @@ mod document_decrypt_result {
 mod document_decrypt_unmanaged_result {
     use super::*;
     /// Generic translation of ironoxide's UserOrGroup enum
-    pub struct UserOrGroupJ {
+    #[derive(Hash, PartialEq, Eq)]
+    pub struct UserOrGroupId {
         id: String,
         is_user: bool,
     }
 
-    impl UserOrGroupJ {
-        pub fn new(id: String, is_user: bool) -> UserOrGroupJ {
-            UserOrGroupJ { id, is_user }
+    impl UserOrGroupId {
+        pub fn new(id: String, is_user: bool) -> UserOrGroupId {
+            UserOrGroupId { id, is_user }
         }
         pub fn id(&self) -> String {
             self.id.clone()
@@ -585,19 +587,19 @@ mod document_decrypt_unmanaged_result {
     pub fn decrypted_data(d: &DocumentDecryptUnmanagedResult) -> Vec<i8> {
         u8_conv(d.decrypted_data()).to_vec()
     }
-    pub fn access_via(d: &DocumentDecryptUnmanagedResult) -> UserOrGroupJ {
+    pub fn access_via(d: &DocumentDecryptUnmanagedResult) -> UserOrGroupId {
         let (id, is_user) = match d.access_via() {
             UserOrGroup::User { id } => (id.id().to_string(), true),
             UserOrGroup::Group { id } => (id.id().to_string(), false),
         };
-        UserOrGroupJ::new(id, is_user)
+        UserOrGroupId::new(id, is_user)
     }
 }
 
 // UserAccessErr and GroupAccessErr are a Java-compatible representation of IronOxide's
 // DocAccessEditErr. They are encoded this this because this seemed like the most
 // straightforward way to represent a error for both a user or group (like UserOrGroup)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct UserAccessErr {
     id: UserId,
     err: String,
@@ -615,6 +617,7 @@ impl UserAccessErr {
 
 /// Wrap the Vec<UserId> type in a newtype because swig can't handle
 /// passing through an Option<Vec<*>> for GroupGetResult
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GroupUserList(Vec<UserId>);
 impl GroupUserList {
     pub fn list(&self) -> Vec<UserId> {
@@ -622,7 +625,7 @@ impl GroupUserList {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GroupAccessErr {
     id: GroupId,
     err: String,
@@ -642,6 +645,7 @@ mod document_access_change_result {
     use super::*;
     use itertools::{Either, Itertools};
 
+    #[derive(Hash, PartialEq)]
     pub struct SucceededResult {
         users: Vec<UserId>,
         groups: Vec<GroupId>,
@@ -656,6 +660,7 @@ mod document_access_change_result {
         }
     }
 
+    #[derive(Hash, PartialEq)]
     pub struct FailedResult {
         users: Vec<UserAccessErr>,
         groups: Vec<GroupAccessErr>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,10 @@ use std::{
 
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 
-pub fn hash<T: Hash>(t: &T) -> i16 {
+pub fn hash<T: Hash>(t: &T) -> i32 {
     let mut s = DefaultHasher::new();
     t.hash(&mut s);
-    s.finish() as i16
+    s.finish() as i32
 }
 
 pub fn eq<T: PartialEq>(t: &T, other: &T) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,11 @@ pub fn hash<T: Hash>(t: &T) -> i32 {
     s.finish() as i32
 }
 
-pub fn eq<T: PartialEq>(t: &T, other: &T) -> bool {
+pub fn eq<T: Eq>(t: &T, other: &T) -> bool {
     t.eq(other)
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Eq, Hash, PartialEq)]
 pub struct UserWithKey((UserId, PublicKey));
 impl UserWithKey {
     pub fn user(&self) -> UserId {
@@ -53,7 +53,7 @@ impl UserWithKey {
 }
 
 // This was created because Option<bool> cannot be converted to Java
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Eq, Hash, PartialEq)]
 pub struct NullableBoolean(bool);
 impl NullableBoolean {
     pub fn boolean(&self) -> bool {
@@ -559,7 +559,7 @@ mod document_decrypt_result {
 mod document_decrypt_unmanaged_result {
     use super::*;
     /// Generic translation of ironoxide's UserOrGroup enum
-    #[derive(Hash, PartialEq, Eq)]
+    #[derive(Eq, Hash, PartialEq)]
     pub struct UserOrGroupId {
         id: String,
         is_user: bool,
@@ -599,7 +599,7 @@ mod document_decrypt_unmanaged_result {
 // UserAccessErr and GroupAccessErr are a Java-compatible representation of IronOxide's
 // DocAccessEditErr. They are encoded this this because this seemed like the most
 // straightforward way to represent a error for both a user or group (like UserOrGroup)
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub struct UserAccessErr {
     id: UserId,
     err: String,
@@ -617,7 +617,7 @@ impl UserAccessErr {
 
 /// Wrap the Vec<UserId> type in a newtype because swig can't handle
 /// passing through an Option<Vec<*>> for GroupGetResult
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Eq, Hash, PartialEq)]
 pub struct GroupUserList(Vec<UserId>);
 impl GroupUserList {
     pub fn list(&self) -> Vec<UserId> {
@@ -625,7 +625,7 @@ impl GroupUserList {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub struct GroupAccessErr {
     id: GroupId,
     err: String,
@@ -645,7 +645,7 @@ mod document_access_change_result {
     use super::*;
     use itertools::{Either, Itertools};
 
-    #[derive(Hash, PartialEq)]
+    #[derive(Eq, Hash, PartialEq)]
     pub struct SucceededResult {
         users: Vec<UserId>,
         groups: Vec<GroupId>,
@@ -660,7 +660,7 @@ mod document_access_change_result {
         }
     }
 
-    #[derive(Hash, PartialEq)]
+    #[derive(Eq, Hash, PartialEq)]
     pub struct FailedResult {
         users: Vec<UserAccessErr>,
         groups: Vec<GroupAccessErr>,

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -17,6 +17,22 @@ class PublicKey {
     private constructor = empty;
     static_method public_key::validate(bytes: &[i8]) -> Result<PublicKey, String>;
     method public_key::as_bytes(&self) -> Vec<i8>; alias asBytes;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.asBytes().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof PublicKey){
+            PublicKey key = (PublicKey) obj;
+            return java.util.Arrays.equals(key.asBytes(), this.asBytes());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -27,6 +43,22 @@ class PrivateKey {
     private constructor = empty;
     static_method private_key::validate(bytes: &[i8]) -> Result<PrivateKey, String>;
     method private_key::as_bytes(&self) -> Vec<i8>; alias asBytes;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.asBytes().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof PrivateKey){
+            PrivateKey key = (PrivateKey) obj;
+            return java.util.Arrays.equals(key.asBytes(), this.asBytes());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -37,6 +69,22 @@ class DeviceSigningKeyPair {
     private constructor = empty;
     static_method device_signing_keys::validate(bytes: &[i8]) -> Result<DeviceSigningKeyPair, String>;
     method device_signing_keys::as_bytes(&self) -> Vec<i8>; alias asBytes;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.asBytes().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DeviceSigningKeyPair){
+            DeviceSigningKeyPair key = (DeviceSigningKeyPair) obj;
+            return java.util.Arrays.equals(key.asBytes(), this.asBytes());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -148,12 +196,27 @@ class GroupName {
 });
 
 foreigner_class!(
-    class NullableBoolean{
-        self_type NullableBoolean;
-        private constructor = empty;
-        method NullableBoolean::boolean(&self) -> bool; alias getBoolean;
+class NullableBoolean{
+    self_type NullableBoolean;
+    private constructor = empty;
+    method NullableBoolean::boolean(&self) -> bool; alias getBoolean;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return Boolean.hashCode(this.getBoolean());
     }
-);
+    public boolean equals(Object obj) {
+        if(obj instanceof NullableBoolean){
+            NullableBoolean b = (NullableBoolean) obj;
+            return b.getBoolean() == this.getBoolean();
+        }
+        return false;
+    }
+"#;
+});
 
 foreigner_class!(
 /// ID of a document. Unique within the segment. Must match the regex `^[a-zA-Z0-9_.$#|@/:;=+'-]+$`.
@@ -314,6 +377,22 @@ class VisibleUser {
     self_type VisibleUser;
     private constructor = empty;
     method visible_user::id(&self) -> UserId; alias getId;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof VisibleUser){
+            VisibleUser user = (VisibleUser) obj;
+            return user.getId().equals(this.getId());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -323,6 +402,23 @@ class VisibleGroup {
     private constructor = empty;
     method visible_group::id(&self) -> GroupId; alias getId;
     method visible_group::name(&self) -> Option<GroupName>; alias getName;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode() * this.getName().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof VisibleGroup){
+            VisibleGroup group = (VisibleGroup) obj;
+            return group.getId().equals(this.getId()) && 
+            group.getName().equals(this.getName());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -332,6 +428,23 @@ class UserAccessErr {
     private constructor = empty;
     method UserAccessErr::id(&self) -> UserId; alias getId;
     method UserAccessErr::err(&self) -> String; alias getErr;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode() * this.getErr().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof UserAccessErr){
+            UserAccessErr uae = (UserAccessErr) obj;
+            return uae.getId().equals(this.getId()) && 
+            uae.getErr().equals(this.getErr());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -341,6 +454,23 @@ class GroupAccessErr {
     private constructor = empty;
     method GroupAccessErr::id(&self) -> GroupId; alias getId;
     method GroupAccessErr::err(&self) -> String; alias getErr;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode() * this.getErr().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof GroupAccessErr){
+            GroupAccessErr gae = (GroupAccessErr) obj;
+            return gae.getId().equals(this.getId()) && 
+            gae.getErr().equals(this.getErr());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(class UserWithKey {
@@ -348,12 +478,45 @@ foreigner_class!(class UserWithKey {
     private constructor = empty;
     method UserWithKey::user(&self) -> UserId; alias getUser;
     method UserWithKey::public_key(&self) -> PublicKey; alias getPublicKey;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getUser().hashCode() * this.getPublicKey().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof UserWithKey){
+            UserWithKey uwk = (UserWithKey) obj;
+            return uwk.getUser().equals(this.getUser()) && 
+            uwk.getPublicKey().equals(this.getPublicKey());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(class GroupUserList {
     self_type GroupUserList;
     private constructor = empty;
     method GroupUserList::list(&self) -> Vec<UserId>; alias getList;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getList().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof GroupUserList){
+            GroupUserList gul = (GroupUserList) obj;
+            return java.util.Arrays.equals(gul.getList(), this.getList());
+        }
+        return false;
+    }
+"#;
 });
 
 ///
@@ -372,6 +535,26 @@ class DeviceContext {
     method device_context::signing_private_key(&self) -> DeviceSigningKeyPair; alias getSigningPrivateKey;
     method device_context::to_json_string(&self) -> String; alias toJsonString;
     static_method device_context::from_json_string(jsonString: &str) -> Result<DeviceContext, String>; alias fromJsonString;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getAccountId().hashCode() * Long.hashCode(this.getSegmentId()) * 
+        this.getDevicePrivateKey().hashCode() * this.getSigningPrivateKey().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DeviceContext){
+            DeviceContext device = (DeviceContext) obj;
+            return device.getAccountId().equals(this.getAccountId()) && 
+            device.getSegmentId() == this.getSegmentId() && 
+            device.getDevicePrivateKey().equals(this.getDevicePrivateKey()) && 
+            device.getSigningPrivateKey().equals(this.getSigningPrivateKey());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -395,6 +578,32 @@ class DeviceAddResult {
     method device_add_result::created(&self) -> DateTime<Utc>; alias getCreated;
     /// The date and time that the device was last updated
     method device_add_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getAccountId().hashCode() * Long.hashCode(this.getSegmentId()) * 
+        this.getDevicePrivateKey().hashCode() * this.getSigningPrivateKey().hashCode() *
+        this.getDeviceId().hashCode() * this.getName().hashCode() * this.getCreated().hashCode() *
+        this.getLastUpdated().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DeviceAddResult){
+            DeviceAddResult device = (DeviceAddResult) obj;
+            return device.getAccountId().equals(this.getAccountId()) && 
+            device.getSegmentId() == this.getSegmentId() && 
+            device.getDevicePrivateKey().equals(this.getDevicePrivateKey()) && 
+            device.getSigningPrivateKey().equals(this.getSigningPrivateKey()) &&
+            device.getDeviceId().equals(this.getDeviceId()) && 
+            device.getName().equals(this.getName()) && 
+            device.getCreated().equals(this.getCreated()) && 
+            device.getLastUpdated().equals(this.getLastUpdated());
+        }
+        return false;
+    }
+"#;
 });
 
 ///
@@ -409,6 +618,23 @@ class UserCreateResult {
     method user_create_result::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
     /// True if the private key of the user's keypair needs to be rotated, else false.
     method user_create_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getUserPublicKey().hashCode() * Boolean.hashCode(this.getNeedsRotation());
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof UserCreateResult){
+            UserCreateResult ucr = (UserCreateResult) obj;
+            return ucr.getUserPublicKey().equals(this.getUserPublicKey()) && 
+            ucr.getNeedsRotation() == this.getNeedsRotation();
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -420,6 +646,26 @@ class UserResult {
     method user_result::segment_id(&self) -> usize; alias getSegmentId;
     method user_result::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
     method user_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getAccountId().hashCode() * Long.hashCode(this.getSegmentId()) *
+        this.getUserPublicKey().hashCode() * Boolean.hashCode(this.getNeedsRotation());
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof UserResult){
+            UserResult ur = (UserResult) obj;
+            return ur.getAccountId().equals(this.getAccountId()) && 
+            ur.getSegmentId() == this.getSegmentId() &&
+            ur.getUserPublicKey().equals(this.getUserPublicKey()) &&
+            ur.getNeedsRotation() == this.getNeedsRotation();
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -438,6 +684,28 @@ class UserDevice {
     /// True if this device instance is the one that was used to make
     /// the API request
     method UserDevice::is_current_device(&self) -> bool; alias isCurrentDevice;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode() * this.getName().hashCode() *
+        this.getLastUpdated().hashCode() * this.getCreated().hashCode() *
+        Boolean.hashCode(this.isCurrentDevice());
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof UserDevice){
+            UserDevice ud = (UserDevice) obj;
+            return ud.getId().equals(this.getId()) && 
+            ud.getName().equals(this.getName()) &&
+            ud.getLastUpdated().equals(this.getLastUpdated()) &&
+            ud.getCreated().equals(this.getCreated()) &&
+            ud.isCurrentDevice() == this.isCurrentDevice();
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(class DeviceCreateOpts {

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -144,7 +144,6 @@ foreigner_class!(
 class UserOrGroupId {
     self_type UserOrGroupJ;
     private constructor = empty;
-
     method UserOrGroupJ::id(&self) -> String; alias getId;
     method UserOrGroupJ::is_user(&self) -> bool; alias isUser;
     method UserOrGroupJ::is_group(&self) -> bool; alias isGroup;
@@ -166,7 +165,6 @@ foreigner_code r#"
         return false;
     }
 "#;
-
 });
 
 foreigner_class!(
@@ -176,7 +174,6 @@ class GroupName {
     private constructor = empty;
     static_method group_name::validate(s: &str) -> Result<GroupName, String>;
     method group_name::name(&self) -> String; alias getName;
-    method GroupName::clone(&self) -> GroupName;
     foreigner_code r#"
     /**
      * This implementation calls native code, which means it's relatively slow.
@@ -250,7 +247,6 @@ class DocumentName {
     private constructor = empty;
     static_method document_name::validate(s: &str) -> Result<DocumentName, String>;
     method document_name::name(&self) -> String; alias getName;
-    method DocumentName::clone(&self) -> DocumentName;
     foreigner_code r#"
     /**
      * This implementation calls native code, which means it's relatively slow.
@@ -276,7 +272,6 @@ class DeviceId {
     private constructor = empty;
     static_method device_id::validate(s: i64) -> Result<DeviceId, String>;
     method device_id::id(&self) -> i64; alias getId;
-    method DeviceId::clone(&self) -> DeviceId;
     foreigner_code r#"
     /**
      * This implementation calls native code, which means it's relatively slow.
@@ -352,7 +347,6 @@ class DeviceName {
     private constructor = empty;
     static_method device_name::validate(s: &str) -> Result<DeviceName, String>;
     method device_name::name(&self) -> String; alias getName;
-    method DeviceName::clone(&self) -> DeviceName;
     foreigner_code r#"
     /**
      * This implementation calls native code, which means it's relatively slow.
@@ -915,18 +909,18 @@ foreigner_class!(class GroupGetResult{
         this.getNeedsRotation().hashCode();
     }
     public boolean equals(Object obj) {
-        if(obj instanceof GroupCreateResult){
-            GroupCreateResult gcr = (GroupCreateResult) obj;
-            return gcr.getId().equals(this.getId()) && 
-            gcr.getName().equals(this.getName()) &&
-            gcr.getGroupMasterPublicKey().equals(this.getGroupMasterPublicKey()) &&
-            gcr.isAdmin() == this.isAdmin() &&
-            gcr.isMember() == this.isMember() &&
-            gcr.getCreated().equals(this.getCreated()) &&
-            gcr.getLastUpdated().equals(this.getLastUpdated()) &&
-            gcr.getAdminList().equals(this.getAdminList()) &&
-            gcr.getMemberList().equals(this.getMemberList()) &&
-            gcr.getNeedsRotation().equals(this.getNeedsRotation());
+        if(obj instanceof GroupGetResult){
+            GroupGetResult ggr = (GroupGetResult) obj;
+            return ggr.getId().equals(this.getId()) && 
+            ggr.getName().equals(this.getName()) &&
+            ggr.getGroupMasterPublicKey().equals(this.getGroupMasterPublicKey()) &&
+            ggr.isAdmin() == this.isAdmin() &&
+            ggr.isMember() == this.isMember() &&
+            ggr.getCreated().equals(this.getCreated()) &&
+            ggr.getLastUpdated().equals(this.getLastUpdated()) &&
+            ggr.getAdminList().equals(this.getAdminList()) &&
+            ggr.getMemberList().equals(this.getMemberList()) &&
+            ggr.getNeedsRotation().equals(this.getNeedsRotation());
         }
         return false;
     }
@@ -1563,8 +1557,8 @@ foreigner_class!(
 class Duration{
     self_type Duration;
     private constructor = empty;
-    static_method Duration::from_millis(millis: u64) -> Duration;
-    static_method Duration::from_secs(secs: u64) -> Duration;
+    static_method Duration::from_millis(millis: u64) -> Duration; alias fromMillis;
+    static_method Duration::from_secs(secs: u64) -> Duration; alias fromSecs;
     method duration::get_millis(&self) -> u64; alias getMillis;
     method duration::get_secs(&self) -> u64; alias getSecs;
     foreigner_code r#"

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -23,7 +23,7 @@ class PublicKey {
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.asBytes().hashCode();
+        return java.util.Arrays.hashCode(this.asBytes());
     }
     public boolean equals(Object obj) {
         if(obj instanceof PublicKey){
@@ -49,7 +49,7 @@ class PrivateKey {
      */
     @Override
     public int hashCode() {
-        return this.asBytes().hashCode();
+        return java.util.Arrays.hashCode(this.asBytes());
     }
     public boolean equals(Object obj) {
         if(obj instanceof PrivateKey){
@@ -75,7 +75,7 @@ class DeviceSigningKeyPair {
      */
     @Override
     public int hashCode() {
-        return this.asBytes().hashCode();
+        return java.util.Arrays.hashCode(this.asBytes());
     }
     public boolean equals(Object obj) {
         if(obj instanceof DeviceSigningKeyPair){
@@ -95,18 +95,17 @@ class UserId {
     private constructor = empty;
     static_method user_id::validate(s: &str) -> Result<UserId, String>;
     method user_id::id(&self) -> String; alias getId;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
+    
+    private fn hash(&self) -> i16; alias rustHash;
+    private fn eq(&self, o: &UserId) -> bool; alias rustEq;
+    foreign_code r#"
     public int hashCode() {
-        return this.getId().hashCode();
+        return this.rustHash();
     }
     public boolean equals(Object obj) {
         if(obj instanceof UserId){
-            UserId id = (UserId) obj;
-            return id.getId().equals(this.getId());
+            UserId other = (UserId) obj;
+            return other.rustEq(this);
         }
         return false;
     }
@@ -121,18 +120,17 @@ class GroupId {
     private constructor = empty;
     static_method group_id::validate(s: &str) -> Result<GroupId, String>;
     method group_id::id(&self) -> String; alias getId;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
+
+    private fn hash(&self) -> i16; alias rustHash;
+    private fn eq(&self, o: &GroupId) -> bool; alias rustEq;
+    foreign_code r#"
     public int hashCode() {
-        return this.getId().hashCode();
+        return this.rustHash();
     }
     public boolean equals(Object obj) {
         if(obj instanceof GroupId){
-            GroupId id = (GroupId) obj;
-            return id.getId().equals(this.getId());
+            GroupId other = (GroupId) obj;
+            return other.rustEq(this);
         }
         return false;
     }
@@ -328,7 +326,7 @@ foreigner_class!(
      */
     @Override
     public int hashCode() {
-        return this.asBytes().hashCode();
+        return java.util.Arrays.hashCode(this.asBytes());
     }
     public boolean equals(Object obj) {
         if(obj instanceof EncryptedPrivateKey){
@@ -501,7 +499,7 @@ foreigner_class!(class GroupUserList {
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.getList().hashCode();
+        return java.util.Arrays.hashCode(this.getList());
     }
     public boolean equals(Object obj) {
         if(obj instanceof GroupUserList){
@@ -730,7 +728,7 @@ class UserDeviceListResult {
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.getResult().hashCode();
+        return java.util.Arrays.hashCode(this.getResult());
     }
     public boolean equals(Object obj) {
         if(obj instanceof UserDeviceListResult){
@@ -861,7 +859,7 @@ foreigner_class!(class GroupListResult{
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.getResult().hashCode();
+        return java.util.Arrays.hashCode(this.getResult());
     }
     public boolean equals(Object obj) {
         if(obj instanceof GroupListResult){
@@ -1012,7 +1010,8 @@ class GroupAccessEditResult{
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.getSucceeded().hashCode() * this.getFailed().hashCode();
+        return java.util.Arrays.hashCode(this.getSucceeded()) * 
+        java.util.Arrays.hashCode(this.getFailed());
     }
     public boolean equals(Object obj) {
         if(obj instanceof GroupAccessEditResult){
@@ -1047,18 +1046,17 @@ class Category {
     private constructor = empty;
     static_method category::validate(s: &str) -> Result<Category, String>;
     method category::value(&self) -> String; alias getValue;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
+    
+    private fn hash(&self) -> i16; alias rustHash;
+    private fn eq(&self, o: &Category) -> bool; alias rustEq;
+    foreign_code r#"
     public int hashCode() {
-        return this.getValue().hashCode();
+        return this.rustHash();
     }
     public boolean equals(Object obj) {
         if(obj instanceof Category){
-            Category cat = (Category) obj;
-            return cat.getValue().equals(this.getValue());
+            Category other = (Category) obj;
+            return other.rustEq(this);
         }
         return false;
     }
@@ -1071,18 +1069,17 @@ class Sensitivity {
     private constructor = empty;
     static_method sensitivity::validate(s: &str) -> Result<Sensitivity, String>;
     method sensitivity::value(&self) -> String; alias getValue;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
+    
+    private fn hash(&self) -> i16; alias rustHash;
+    private fn eq(&self, o: &Sensitivity) -> bool; alias rustEq;
+    foreign_code r#"
     public int hashCode() {
-        return this.getValue().hashCode();
+        return this.rustHash();
     }
     public boolean equals(Object obj) {
         if(obj instanceof Sensitivity){
-            Sensitivity sen = (Sensitivity) obj;
-            return sen.getValue().equals(this.getValue());
+            Sensitivity other = (Sensitivity) obj;
+            return other.rustEq(this);
         }
         return false;
     }
@@ -1095,18 +1092,17 @@ class DataSubject {
     private constructor = empty;
     static_method data_subject::validate(s: &str) -> Result<DataSubject, String>;
     method data_subject::value(&self) -> String; alias getValue;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
+    
+    private fn hash(&self) -> i16; alias rustHash;
+    private fn eq(&self, o: &DataSubject) -> bool; alias rustEq;
+    foreign_code r#"
     public int hashCode() {
-        return this.getValue().hashCode();
+        return this.rustHash();
     }
     public boolean equals(Object obj) {
         if(obj instanceof DataSubject){
-            DataSubject sub = (DataSubject) obj;
-            return sub.getValue().equals(this.getValue());
+            DataSubject other = (DataSubject) obj;
+            return other.rustEq(this);
         }
         return false;
     }
@@ -1122,22 +1118,17 @@ class PolicyGrant {
     method policy_grant::sensitivity(&self) -> Option<Sensitivity>; alias getSensitivity;
     method policy_grant::data_subject(&self) -> Option<DataSubject>; alias getDataSubject;
     method policy_grant::substitute_id(&self) -> Option<UserId>; alias getSubstituteId;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
+    
+    private fn hash(&self) -> i16; alias rustHash;
+    private fn eq(&self, o: &PolicyGrant) -> bool; alias rustEq;
+    foreign_code r#"
     public int hashCode() {
-        return this.getCategory().hashCode() * this.getSensitivity().hashCode() *
-        this.getDataSubject().hashCode() * this.getSubstituteId().hashCode();
+        return this.rustHash();
     }
     public boolean equals(Object obj) {
         if(obj instanceof PolicyGrant){
-            PolicyGrant pg = (PolicyGrant) obj;
-            return pg.getCategory().equals(this.getCategory()) &&
-            pg.getSensitivity().equals(this.getSensitivity()) &&
-            pg.getDataSubject().equals(this.getDataSubject()) &&
-            pg.getSubstituteId().equals(this.getSubstituteId());
+            PolicyGrant other = (PolicyGrant) obj;
+            return other.rustEq(this);
         }
         return false;
     }
@@ -1206,7 +1197,7 @@ class DocumentListResult{
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.getResult().hashCode();
+        return java.util.Arrays.hashCode(this.getResult());
     }
     public boolean equals(Object obj) {
         if(obj instanceof DocumentListResult){
@@ -1238,8 +1229,8 @@ class DocumentMetadataResult{
     public int hashCode() {
         return this.getId().hashCode() * this.getName().hashCode() *
         this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
-        this.getAssociationType().hashCode() * this.getVisibleToUsers().hashCode() *
-        this.getVisibleToGroups().hashCode();
+        this.getAssociationType().hashCode() * java.util.Arrays.hashCode(this.getVisibleToUsers()) *
+        java.util.Arrays.hashCode(this.getVisibleToGroups());
     }
     public boolean equals(Object obj) {
         if(obj instanceof DocumentMetadataResult){
@@ -1282,7 +1273,7 @@ class DocumentEncryptResult{
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.getId().hashCode() * this.getName().hashCode() * this.getEncryptedData().hashCode() * 
+        return this.getId().hashCode() * this.getName().hashCode() * java.util.Arrays.hashCode(this.getEncryptedData()) * 
         this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
         this.getChanged().hashCode() * this.getErrors().hashCode();
     }
@@ -1322,8 +1313,8 @@ class DocumentEncryptUnmanagedResult {
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.getId().hashCode() * this.getEncryptedData().hashCode() * this.getEncryptedDeks().hashCode() *
-        this.getChanged().hashCode() * this.getErrors().hashCode();
+        return this.getId().hashCode() * java.util.Arrays.hashCode(this.getEncryptedData()) * 
+        java.util.Arrays.hashCode(this.getEncryptedDeks()) * this.getChanged().hashCode() * this.getErrors().hashCode();
     }
     public boolean equals(Object obj) {
         if(obj instanceof DocumentEncryptUnmanagedResult){
@@ -1355,7 +1346,7 @@ class DocumentDecryptResult{
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.getId().hashCode() * this.getName().hashCode() * this.getDecryptedData().hashCode() *
+        return this.getId().hashCode() * this.getName().hashCode() * java.util.Arrays.hashCode(this.getDecryptedData()) *
         this.getCreated().hashCode() * this.getLastUpdated().hashCode();
     }
     public boolean equals(Object obj) {
@@ -1390,7 +1381,7 @@ class DocumentDecryptUnmanagedResult{
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.getId().hashCode() * this.getDecryptedData().hashCode() *
+        return this.getId().hashCode() * java.util.Arrays.hashCode(this.getDecryptedData()) *
         this.getAccessViaUserOrGroup().hashCode();
     }
     public boolean equals(Object obj) {
@@ -1420,7 +1411,7 @@ class SucceededResult {
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.getUsers().hashCode() * this.getGroups().hashCode();
+        return java.util.Arrays.hashCode(this.getUsers()) * java.util.Arrays.hashCode(this.getGroups());
     }
     public boolean equals(Object obj) {
         if(obj instanceof SucceededResult){
@@ -1450,7 +1441,7 @@ class FailedResult {
      * This implementation calls native code, which means it's relatively slow.
      */
     public int hashCode() {
-        return this.getUsers().hashCode() * this.getGroups().hashCode() *
+        return java.util.Arrays.hashCode(this.getUsers()) * java.util.Arrays.hashCode(this.getGroups()) *
         Boolean.hashCode(this.isEmpty());
     }
     public boolean equals(Object obj) {
@@ -1506,18 +1497,17 @@ class PolicyCachingConfig{
     constructor policy_caching_config::create(maxEntries: usize) -> PolicyCachingConfig;
     constructor PolicyCachingConfig::default() -> PolicyCachingConfig;
     method policy_caching_config::get_max_entries(&self) -> usize; alias getMaxEntries;
+    
+    private fn hash(&self) -> i16; alias rustHash;
+    private fn eq(&self, o: &PolicyCachingConfig) -> bool; alias rustEq;
     foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
     public int hashCode() {
-        return Long.hashCode(this.getMaxEntries());
+        return this.rustHash();
     }
     public boolean equals(Object obj) {
         if(obj instanceof PolicyCachingConfig){
-            PolicyCachingConfig pcc = (PolicyCachingConfig) obj;
-            return pcc.getMaxEntries() == this.getMaxEntries();
+            PolicyCachingConfig other = (PolicyCachingConfig) obj;
+            return other.rustEq(this);
         }
         return false;
     }
@@ -1534,19 +1524,17 @@ class IronOxideConfig{
     constructor ironoxide_config::create(policyCaching: &PolicyCachingConfig, sdkOperationTimeout: Option<&Duration>) -> IronOxideConfig;
     method ironoxide_config::get_policy_caching(&self) -> PolicyCachingConfig; alias getPolicyCachingConfig; 
     method ironoxide_config::get_timeout(&self) -> Option<Duration>; alias getSdkOperationTimeout;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
+
+    private fn hash(&self) -> i16; alias rustHash;
+    private fn eq(&self, o: &IronOxideConfig) -> bool; alias rustEq;
+    foreign_code r#"
     public int hashCode() {
-        return this.getPolicyCachingConfig().hashCode() * this.getSdkOperationTimeout().hashCode();
+        return this.rustHash();
     }
     public boolean equals(Object obj) {
         if(obj instanceof IronOxideConfig){
-            IronOxideConfig ioc = (IronOxideConfig) obj;
-            return ioc.getPolicyCachingConfig().equals(this.getPolicyCachingConfig()) &&
-            ioc.getSdkOperationTimeout().equals(this.getSdkOperationTimeout());
+            IronOxideConfig other = (IronOxideConfig) obj;
+            return other.rustEq(this);
         }
         return false;
     }
@@ -1561,18 +1549,17 @@ class Duration{
     static_method Duration::from_secs(secs: u64) -> Duration; alias fromSecs;
     method duration::get_millis(&self) -> u64; alias getMillis;
     method duration::get_secs(&self) -> u64; alias getSecs;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
+
+    private fn hash(&self) -> i16; alias rustHash;
+    private fn eq(&self, o: &Duration) -> bool; alias rustEq;
+    foreign_code r#"
     public int hashCode() {
-        return Long.hashCode(this.getMillis());
+        return this.rustHash();
     }
     public boolean equals(Object obj) {
         if(obj instanceof Duration){
-            Duration d = (Duration) obj;
-            return d.getMillis() == this.getMillis();
+            Duration other = (Duration) obj;
+            return other.rustEq(this);
         }
         return false;
     }

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -1,6 +1,6 @@
 use crate::{
     document_access_change_result::{DocumentAccessChange, FailedResult, SucceededResult},
-    document_decrypt_unmanaged_result::UserOrGroupJ,
+    document_decrypt_unmanaged_result::UserOrGroupId,
     jni_c_header::*,
 };
 use chrono::{DateTime, Utc};
@@ -17,22 +17,8 @@ class PublicKey {
     private constructor = empty;
     static_method public_key::validate(bytes: &[i8]) -> Result<PublicKey, String>;
     method public_key::as_bytes(&self) -> Vec<i8>; alias asBytes;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return java.util.Arrays.hashCode(this.asBytes());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof PublicKey){
-            PublicKey key = (PublicKey) obj;
-            return java.util.Arrays.equals(key.asBytes(), this.asBytes());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality PublicKey;
 });
 
 foreigner_class!(
@@ -43,22 +29,8 @@ class PrivateKey {
     private constructor = empty;
     static_method private_key::validate(bytes: &[i8]) -> Result<PrivateKey, String>;
     method private_key::as_bytes(&self) -> Vec<i8>; alias asBytes;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return java.util.Arrays.hashCode(this.asBytes());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof PrivateKey){
-            PrivateKey key = (PrivateKey) obj;
-            return java.util.Arrays.equals(key.asBytes(), this.asBytes());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality PrivateKey;
 });
 
 foreigner_class!(
@@ -69,22 +41,8 @@ class DeviceSigningKeyPair {
     private constructor = empty;
     static_method device_signing_keys::validate(bytes: &[i8]) -> Result<DeviceSigningKeyPair, String>;
     method device_signing_keys::as_bytes(&self) -> Vec<i8>; alias asBytes;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return java.util.Arrays.hashCode(this.asBytes());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DeviceSigningKeyPair){
-            DeviceSigningKeyPair key = (DeviceSigningKeyPair) obj;
-            return java.util.Arrays.equals(key.asBytes(), this.asBytes());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DeviceSigningKeyPair;
 });
 
 foreigner_class!(
@@ -95,7 +53,7 @@ class UserId {
     private constructor = empty;
     static_method user_id::validate(s: &str) -> Result<UserId, String>;
     method user_id::id(&self) -> String; alias getId;
-    fn hash(&self) -> i32; alias hashCode;
+    method hash(&self) -> i32; alias hashCode;
     pre_build_generate_equality UserId;
 });
 
@@ -107,37 +65,20 @@ class GroupId {
     private constructor = empty;
     static_method group_id::validate(s: &str) -> Result<GroupId, String>;
     method group_id::id(&self) -> String; alias getId;
-
-    fn hash(&self) -> i32; alias hashCode;
+    method hash(&self) -> i32; alias hashCode;
     pre_build_generate_equality GroupId;
 });
 
 foreigner_class!(
 /// Either a user id or a group id
 class UserOrGroupId {
-    self_type UserOrGroupJ;
+    self_type UserOrGroupId;
     private constructor = empty;
-    method UserOrGroupJ::id(&self) -> String; alias getId;
-    method UserOrGroupJ::is_user(&self) -> bool; alias isUser;
-    method UserOrGroupJ::is_group(&self) -> bool; alias isGroup;
-
-foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getId().hashCode() * Boolean.hashCode(this.isUser());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof UserOrGroupId){
-            UserOrGroupId uog = (UserOrGroupId) obj;
-            return uog.getId().equals(this.getId()) &&
-            uog.isUser() == this.isUser();
-        }
-        return false;
-    }
-"#;
+    method UserOrGroupId::id(&self) -> String; alias getId;
+    method UserOrGroupId::is_user(&self) -> bool; alias isUser;
+    method UserOrGroupId::is_group(&self) -> bool; alias isGroup;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality UserOrGroupId;
 });
 
 foreigner_class!(
@@ -147,22 +88,8 @@ class GroupName {
     private constructor = empty;
     static_method group_name::validate(s: &str) -> Result<GroupName, String>;
     method group_name::name(&self) -> String; alias getName;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getName().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof GroupName){
-            GroupName name = (GroupName) obj;
-            return name.getName().equals(this.getName());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupName;
 });
 
 foreigner_class!(
@@ -170,22 +97,8 @@ class NullableBoolean{
     self_type NullableBoolean;
     private constructor = empty;
     method NullableBoolean::boolean(&self) -> bool; alias getBoolean;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return Boolean.hashCode(this.getBoolean());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof NullableBoolean){
-            NullableBoolean b = (NullableBoolean) obj;
-            return b.getBoolean() == this.getBoolean();
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality NullableBoolean;
 });
 
 foreigner_class!(
@@ -195,22 +108,8 @@ class DocumentId {
     private constructor = empty;
     static_method document_id::validate(s: &str) -> Result<DocumentId, String>;
     method document_id::id(&self) -> String; alias getId;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getId().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DocumentId){
-            DocumentId id = (DocumentId) obj;
-            return id.getId().equals(this.getId());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DocumentId;
 });
 
 foreigner_class!(
@@ -220,22 +119,8 @@ class DocumentName {
     private constructor = empty;
     static_method document_name::validate(s: &str) -> Result<DocumentName, String>;
     method document_name::name(&self) -> String; alias getName;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getName().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DocumentName){
-            DocumentName name = (DocumentName) obj;
-            return name.getName().equals(this.getName());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DocumentName;
 });
 
 foreigner_class!(
@@ -245,22 +130,8 @@ class DeviceId {
     private constructor = empty;
     static_method device_id::validate(s: i64) -> Result<DeviceId, String>;
     method device_id::id(&self) -> i64; alias getId;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return Long.hashCode(this.getId());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DeviceId){
-            DeviceId id = (DeviceId) obj;
-            return id.getId() == this.getId();
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DeviceId;
 });
 
 foreigner_class!(
@@ -271,23 +142,8 @@ foreigner_class!(
         method user_update_private_key_result::user_master_private_key(&self) -> EncryptedPrivateKey; alias getUserMasterPrivateKey;
         /// True if this user's master key requires rotation
         method user_update_private_key_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
-        foreigner_code r#"
-        /**
-         * This implementation calls native code, which means it's relatively slow.
-         */
-        @Override
-        public int hashCode() {
-            return this.getUserMasterPrivateKey().hashCode() * Boolean.hashCode(this.getNeedsRotation());
-        }
-        public boolean equals(Object obj) {
-            if(obj instanceof UserUpdatePrivateKeyResult){
-                UserUpdatePrivateKeyResult uupkr = (UserUpdatePrivateKeyResult) obj;
-                return (uupkr.getUserMasterPrivateKey().equals(this.getUserMasterPrivateKey()) && 
-                uupkr.getNeedsRotation() == this.getNeedsRotation());
-            }
-            return false;
-        }
-    "#;
+        method hash(&self) -> i32; alias hashCode;
+        pre_build_generate_equality UserUpdatePrivateKeyResult;
 });
 
 foreigner_class!(
@@ -295,22 +151,9 @@ foreigner_class!(
     self_type EncryptedPrivateKey;
     private constructor = empty;
     method encrypted_private_key::as_bytes(&self) -> Vec<i8>; alias asBytes;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return java.util.Arrays.hashCode(this.asBytes());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof EncryptedPrivateKey){
-            EncryptedPrivateKey epk = (EncryptedPrivateKey) obj;
-            return java.util.Arrays.equals(epk.asBytes(), this.asBytes());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality EncryptedPrivateKey;
+
 });
 
 foreigner_class!(
@@ -320,22 +163,8 @@ class DeviceName {
     private constructor = empty;
     static_method device_name::validate(s: &str) -> Result<DeviceName, String>;
     method device_name::name(&self) -> String; alias getName;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getName().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DeviceName){
-            DeviceName name = (DeviceName) obj;
-            return name.getName().equals(this.getName());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DeviceName;
 });
 
 foreigner_class!(
@@ -344,22 +173,8 @@ class VisibleUser {
     self_type VisibleUser;
     private constructor = empty;
     method visible_user::id(&self) -> UserId; alias getId;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getId().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof VisibleUser){
-            VisibleUser user = (VisibleUser) obj;
-            return user.getId().equals(this.getId());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality VisibleUser;
 });
 
 foreigner_class!(
@@ -369,23 +184,8 @@ class VisibleGroup {
     private constructor = empty;
     method visible_group::id(&self) -> GroupId; alias getId;
     method visible_group::name(&self) -> Option<GroupName>; alias getName;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getId().hashCode() * this.getName().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof VisibleGroup){
-            VisibleGroup group = (VisibleGroup) obj;
-            return group.getId().equals(this.getId()) && 
-            group.getName().equals(this.getName());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality VisibleGroup;
 });
 
 foreigner_class!(
@@ -395,23 +195,9 @@ class UserAccessErr {
     private constructor = empty;
     method UserAccessErr::id(&self) -> UserId; alias getId;
     method UserAccessErr::err(&self) -> String; alias getErr;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getId().hashCode() * this.getErr().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof UserAccessErr){
-            UserAccessErr uae = (UserAccessErr) obj;
-            return uae.getId().equals(this.getId()) && 
-            uae.getErr().equals(this.getErr());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality UserAccessErr;
+
 });
 
 foreigner_class!(
@@ -421,23 +207,9 @@ class GroupAccessErr {
     private constructor = empty;
     method GroupAccessErr::id(&self) -> GroupId; alias getId;
     method GroupAccessErr::err(&self) -> String; alias getErr;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getId().hashCode() * this.getErr().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof GroupAccessErr){
-            GroupAccessErr gae = (GroupAccessErr) obj;
-            return gae.getId().equals(this.getId()) && 
-            gae.getErr().equals(this.getErr());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupAccessErr;
+
 });
 
 foreigner_class!(class UserWithKey {
@@ -445,45 +217,18 @@ foreigner_class!(class UserWithKey {
     private constructor = empty;
     method UserWithKey::user(&self) -> UserId; alias getUser;
     method UserWithKey::public_key(&self) -> PublicKey; alias getPublicKey;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getUser().hashCode() * this.getPublicKey().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof UserWithKey){
-            UserWithKey uwk = (UserWithKey) obj;
-            return uwk.getUser().equals(this.getUser()) && 
-            uwk.getPublicKey().equals(this.getPublicKey());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality UserWithKey;
+
 });
 
 foreigner_class!(class GroupUserList {
     self_type GroupUserList;
     private constructor = empty;
     method GroupUserList::list(&self) -> Vec<UserId>; alias getList;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return java.util.Arrays.hashCode(this.getList());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof GroupUserList){
-            GroupUserList gul = (GroupUserList) obj;
-            return java.util.Arrays.equals(gul.getList(), this.getList());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupUserList;
+
 });
 
 ///
@@ -502,26 +247,8 @@ class DeviceContext {
     method device_context::signing_private_key(&self) -> DeviceSigningKeyPair; alias getSigningPrivateKey;
     method device_context::to_json_string(&self) -> String; alias toJsonString;
     static_method device_context::from_json_string(jsonString: &str) -> Result<DeviceContext, String>; alias fromJsonString;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getAccountId().hashCode() * Long.hashCode(this.getSegmentId()) * 
-        this.getDevicePrivateKey().hashCode() * this.getSigningPrivateKey().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DeviceContext){
-            DeviceContext device = (DeviceContext) obj;
-            return device.getAccountId().equals(this.getAccountId()) && 
-            device.getSegmentId() == this.getSegmentId() && 
-            device.getDevicePrivateKey().equals(this.getDevicePrivateKey()) && 
-            device.getSigningPrivateKey().equals(this.getSigningPrivateKey());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DeviceContext;
 });
 
 foreigner_class!(
@@ -545,32 +272,8 @@ class DeviceAddResult {
     method device_add_result::created(&self) -> DateTime<Utc>; alias getCreated;
     /// The date and time that the device was last updated
     method device_add_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getAccountId().hashCode() * Long.hashCode(this.getSegmentId()) * 
-        this.getDevicePrivateKey().hashCode() * this.getSigningPrivateKey().hashCode() *
-        this.getDeviceId().hashCode() * this.getName().hashCode() * this.getCreated().hashCode() *
-        this.getLastUpdated().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DeviceAddResult){
-            DeviceAddResult device = (DeviceAddResult) obj;
-            return device.getAccountId().equals(this.getAccountId()) && 
-            device.getSegmentId() == this.getSegmentId() && 
-            device.getDevicePrivateKey().equals(this.getDevicePrivateKey()) && 
-            device.getSigningPrivateKey().equals(this.getSigningPrivateKey()) &&
-            device.getDeviceId().equals(this.getDeviceId()) && 
-            device.getName().equals(this.getName()) && 
-            device.getCreated().equals(this.getCreated()) && 
-            device.getLastUpdated().equals(this.getLastUpdated());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DeviceAddResult;
 });
 
 ///
@@ -585,23 +288,9 @@ class UserCreateResult {
     method user_create_result::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
     /// True if the private key of the user's keypair needs to be rotated, else false.
     method user_create_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getUserPublicKey().hashCode() * Boolean.hashCode(this.getNeedsRotation());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof UserCreateResult){
-            UserCreateResult ucr = (UserCreateResult) obj;
-            return ucr.getUserPublicKey().equals(this.getUserPublicKey()) && 
-            ucr.getNeedsRotation() == this.getNeedsRotation();
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality UserCreateResult;
+
 });
 
 foreigner_class!(
@@ -613,26 +302,9 @@ class UserResult {
     method user_result::segment_id(&self) -> usize; alias getSegmentId;
     method user_result::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
     method user_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getAccountId().hashCode() * Long.hashCode(this.getSegmentId()) *
-        this.getUserPublicKey().hashCode() * Boolean.hashCode(this.getNeedsRotation());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof UserResult){
-            UserResult ur = (UserResult) obj;
-            return ur.getAccountId().equals(this.getAccountId()) && 
-            ur.getSegmentId() == this.getSegmentId() &&
-            ur.getUserPublicKey().equals(this.getUserPublicKey()) &&
-            ur.getNeedsRotation() == this.getNeedsRotation();
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality UserResult;
+
 });
 
 foreigner_class!(
@@ -651,28 +323,9 @@ class UserDevice {
     /// True if this device instance is the one that was used to make
     /// the API request
     method UserDevice::is_current_device(&self) -> bool; alias isCurrentDevice;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getId().hashCode() * this.getName().hashCode() *
-        this.getLastUpdated().hashCode() * this.getCreated().hashCode() *
-        Boolean.hashCode(this.isCurrentDevice());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof UserDevice){
-            UserDevice ud = (UserDevice) obj;
-            return ud.getId().equals(this.getId()) && 
-            ud.getName().equals(this.getName()) &&
-            ud.getLastUpdated().equals(this.getLastUpdated()) &&
-            ud.getCreated().equals(this.getCreated()) &&
-            ud.isCurrentDevice() == this.isCurrentDevice();
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality UserDevice;
+
 });
 
 foreigner_class!(class DeviceCreateOpts {
@@ -680,6 +333,8 @@ foreigner_class!(class DeviceCreateOpts {
     //Construct the DeviceCreateOpts with `null` for name.
     constructor DeviceCreateOpts::default() -> DeviceCreateOpts;
     static_method device_create_opts::create(name: Option<&DeviceName>) -> DeviceCreateOpts;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DeviceCreateOpts;
 });
 
 foreigner_class!(
@@ -689,6 +344,8 @@ class UserCreateOpts {
     //Construct the UserCreateOpts with a needs_rotation of false.
     constructor UserCreateOpts::default() -> UserCreateOpts;
     static_method user_create_opts::create(needsRotation: bool) -> UserCreateOpts;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality UserCreateOpts;
 });
 
 foreigner_class!(
@@ -697,22 +354,9 @@ class UserDeviceListResult {
     self_type UserDeviceListResult;
     private constructor = empty;
     method user_device_list_result::result(&self) -> Vec<UserDevice>; alias getResult;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return java.util.Arrays.hashCode(this.getResult());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof UserDeviceListResult){
-            UserDeviceListResult udlr = (UserDeviceListResult) obj;
-            return java.util.Arrays.equals(udlr.getResult(), this.getResult());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality UserDeviceListResult;
+
 });
 
 ///
@@ -738,31 +382,9 @@ class GroupMetaResult{
     method group_meta_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
     /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
     method group_meta_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getId().hashCode() * this.getName().hashCode() *
-        Boolean.hashCode(this.isAdmin()) * Boolean.hashCode(this.isMember()) *
-        this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
-        this.getNeedsRotation().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof GroupMetaResult){
-            GroupMetaResult gmr = (GroupMetaResult) obj;
-            return gmr.getId().equals(this.getId()) && 
-            gmr.getName().equals(this.getName()) &&
-            gmr.isAdmin() == this.isAdmin() &&
-            gmr.isMember() == this.isMember() &&
-            gmr.getCreated().equals(this.getCreated()) &&
-            gmr.getLastUpdated().equals(this.getLastUpdated()) &&
-            gmr.getNeedsRotation().equals(this.getNeedsRotation());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupMetaResult;
+
 });
 
 foreigner_class!(
@@ -792,58 +414,18 @@ class GroupCreateResult{
     method group_create_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
     /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
     method group_create_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getId().hashCode() * this.getName().hashCode() * this.getGroupMasterPublicKey().hashCode() *
-        Boolean.hashCode(this.isAdmin()) * Boolean.hashCode(this.isMember()) * this.getOwner().hashCode() *
-        this.getAdminList().hashCode() * this.getMemberList().hashCode() *
-        this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
-        this.getNeedsRotation().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof GroupCreateResult){
-            GroupCreateResult gcr = (GroupCreateResult) obj;
-            return gcr.getId().equals(this.getId()) && 
-            gcr.getName().equals(this.getName()) &&
-            gcr.getGroupMasterPublicKey().equals(this.getGroupMasterPublicKey()) &&
-            gcr.isAdmin() == this.isAdmin() &&
-            gcr.isMember() == this.isMember() &&
-            gcr.getOwner().equals(this.getOwner()) &&
-            gcr.getAdminList().equals(this.getAdminList()) &&
-            gcr.getMemberList().equals(this.getMemberList()) &&
-            gcr.getCreated().equals(this.getCreated()) &&
-            gcr.getLastUpdated().equals(this.getLastUpdated()) &&
-            gcr.getNeedsRotation().equals(this.getNeedsRotation());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupCreateResult;
+
 });
 
 foreigner_class!(class GroupListResult{
     self_type GroupListResult;
     private constructor = empty;
     method group_list_result::result(&self) -> Vec<GroupMetaResult>; alias getResult;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return java.util.Arrays.hashCode(this.getResult());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof GroupListResult){
-            GroupListResult glr = (GroupListResult) obj;
-            return java.util.Arrays.equals(glr.getResult(), this.getResult());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupListResult;
+
 });
 
 foreigner_class!(class GroupGetResult{
@@ -869,61 +451,23 @@ foreigner_class!(class GroupGetResult{
     method group_get_result::member_list(&self) -> Option<GroupUserList>; alias getMemberList;
     /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
     method group_get_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
-    foreigner_code r#"
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    @Override
-    public int hashCode() {
-        return this.getId().hashCode() * this.getName().hashCode() * this.getGroupMasterPublicKey().hashCode() *
-        Boolean.hashCode(this.isAdmin()) * Boolean.hashCode(this.isMember()) *
-        this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
-        this.getAdminList().hashCode() * this.getMemberList().hashCode() *
-        this.getNeedsRotation().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof GroupGetResult){
-            GroupGetResult ggr = (GroupGetResult) obj;
-            return ggr.getId().equals(this.getId()) && 
-            ggr.getName().equals(this.getName()) &&
-            ggr.getGroupMasterPublicKey().equals(this.getGroupMasterPublicKey()) &&
-            ggr.isAdmin() == this.isAdmin() &&
-            ggr.isMember() == this.isMember() &&
-            ggr.getCreated().equals(this.getCreated()) &&
-            ggr.getLastUpdated().equals(this.getLastUpdated()) &&
-            ggr.getAdminList().equals(this.getAdminList()) &&
-            ggr.getMemberList().equals(this.getMemberList()) &&
-            ggr.getNeedsRotation().equals(this.getNeedsRotation());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupGetResult;
+
 });
 
-foreigner_class!(class GroupUpdatePrivateKeyResult{
+foreigner_class!(
+/// Result of rotating group private key.
+class GroupUpdatePrivateKeyResult{
     self_type GroupUpdatePrivateKeyResult;
     private constructor = empty;
     /// true if the group still needs rotation, else false
     method group_update_private_key_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
     /// the id of the group whose private key was rotated
     method group_update_private_key_result::id(&self) -> GroupId; alias getId;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return this.getId().hashCode() * Boolean.hashCode(this.getNeedsRotation());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof GroupUpdatePrivateKeyResult){
-            GroupUpdatePrivateKeyResult gupkr = (GroupUpdatePrivateKeyResult) obj;
-            return gupkr.getId().equals(this.getId()) && 
-            gupkr.getNeedsRotation() == this.getNeedsRotation();
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupUpdatePrivateKeyResult;
+
 });
 
 foreigner_class!(
@@ -940,6 +484,8 @@ class GroupCreateOpts {
     /// @param members list of users to be added as members of the group. This list takes priority over `addAsMember`, so the creating user will be added as a member even if `addAsMember` is false.
     /// @param needsRotation if true, the group will be marked as needing its private key rotated.
     static_method group_create_opts::create(id: Option<&GroupId>, name: Option<&GroupName>, addAsAdmin: bool, addAsMember: bool, owner: Option<&UserId>, admins: Vec<UserId>, members: Vec<UserId>, needsRotation: bool) -> GroupCreateOpts;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupCreateOpts;
 });
 
 foreigner_class!(
@@ -951,23 +497,9 @@ class GroupAccessEditErr{
     method access_edit_failure::user(&self) -> UserId; alias getUser;
     /// Get the reason for grant/revoke failure
     method access_edit_failure::error(&self) -> String; alias getError;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return this.getUser().hashCode() * this.getError().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof GroupAccessEditErr){
-            GroupAccessEditErr gaee = (GroupAccessEditErr) obj;
-            return gaee.getUser().equals(this.getUser()) && 
-            gaee.getError().equals(this.getError());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupAccessEditErr;
+
 });
 
 foreigner_class!(
@@ -979,24 +511,9 @@ class GroupAccessEditResult{
     method group_access_edit_result::succeeded(&self) -> Vec<UserId>; alias getSucceeded;
     /// Get the users whose access could not be modified
     method group_access_edit_result::failed(&self) -> Vec<GroupAccessEditErr>; alias getFailed;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return java.util.Arrays.hashCode(this.getSucceeded()) * 
-        java.util.Arrays.hashCode(this.getFailed());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof GroupAccessEditResult){
-            GroupAccessEditResult gaer = (GroupAccessEditResult) obj;
-            return java.util.Arrays.equals(gaer.getSucceeded(), this.getSucceeded()) && 
-            java.util.Arrays.equals(gaer.getFailed(), this.getFailed());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupAccessEditResult;
+
 });
 
 ///
@@ -1021,7 +538,6 @@ class Category {
     private constructor = empty;
     static_method category::validate(s: &str) -> Result<Category, String>;
     method category::value(&self) -> String; alias getValue;
-    
     fn hash(&self) -> i32; alias hashCode;
     pre_build_generate_equality Category;
 });
@@ -1032,7 +548,6 @@ class Sensitivity {
     private constructor = empty;
     static_method sensitivity::validate(s: &str) -> Result<Sensitivity, String>;
     method sensitivity::value(&self) -> String; alias getValue;
-    
     fn hash(&self) -> i32; alias hashCode;
     pre_build_generate_equality Sensitivity;
 });
@@ -1043,7 +558,6 @@ class DataSubject {
     private constructor = empty;
     static_method data_subject::validate(s: &str) -> Result<DataSubject, String>;
     method data_subject::value(&self) -> String; alias getValue;
-    
     fn hash(&self) -> i32; alias hashCode;
     pre_build_generate_equality DataSubject;
 });
@@ -1057,7 +571,6 @@ class PolicyGrant {
     method policy_grant::sensitivity(&self) -> Option<Sensitivity>; alias getSensitivity;
     method policy_grant::data_subject(&self) -> Option<DataSubject>; alias getDataSubject;
     method policy_grant::substitute_id(&self) -> Option<UserId>; alias getSubstituteId;
-    
     fn hash(&self) -> i32; alias hashCode;
     pre_build_generate_equality PolicyGrant;
 });
@@ -1074,6 +587,8 @@ class DocumentEncryptOpts {
     /// @param groupGrants   list of group ids that will be granted access to the document
     /// @param policyGrant   The policy labels which will be evaluated to determine grants. 
     static_method document_create_opt::create(id :Option<&DocumentId>, name :Option<&DocumentName>, grantToAuthor: bool, userGrants: Vec<UserId>, groupGrants: Vec<GroupId>, policyGrant:Option<&PolicyGrant>) -> DocumentEncryptOpts;
+    fn hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DocumentEncryptOpts;
 });
 
 foreigner_class!(
@@ -1088,28 +603,8 @@ class DocumentListMeta{
     method document_list_meta::association_type(&self) -> AssociationType; alias getAssociationType;
     method document_list_meta::created(&self) -> DateTime<Utc>; alias getCreated;
     method document_list_meta::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return this.getId().hashCode() * this.getName().hashCode() *
-        this.getAssociationType().hashCode() * this.getCreated().hashCode() *
-        this.getLastUpdated().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DocumentListMeta){
-            DocumentListMeta dlm = (DocumentListMeta) obj;
-            return dlm.getId().equals(this.getId()) &&
-            dlm.getName().equals(this.getName()) &&
-            dlm.getAssociationType().equals(this.getAssociationType()) &&
-            dlm.getCreated().equals(this.getCreated()) &&
-            dlm.getLastUpdated().equals(this.getLastUpdated());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DocumentListMeta;
 });
 
 foreigner_class!(
@@ -1118,22 +613,8 @@ class DocumentListResult{
     self_type DocumentListResult;
     private constructor = empty;
     method document_list_result::result(&self) -> Vec<DocumentListMeta>; alias getResult;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return java.util.Arrays.hashCode(this.getResult());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DocumentListResult){
-            DocumentListResult dlr = (DocumentListResult) obj;
-            return java.util.Arrays.equals(dlr.getResult(), this.getResult());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DocumentListResult;
 });
 
 foreigner_class!(
@@ -1148,31 +629,8 @@ class DocumentMetadataResult{
     method document_metadata_result::association_type(&self) -> AssociationType; alias getAssociationType;
     method document_metadata_result::visible_to_users(&self) -> Vec<VisibleUser>; alias getVisibleToUsers;
     method document_metadata_result::visible_to_groups(&self) -> Vec<VisibleGroup>; alias getVisibleToGroups;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return this.getId().hashCode() * this.getName().hashCode() *
-        this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
-        this.getAssociationType().hashCode() * java.util.Arrays.hashCode(this.getVisibleToUsers()) *
-        java.util.Arrays.hashCode(this.getVisibleToGroups());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DocumentMetadataResult){
-            DocumentMetadataResult dmr = (DocumentMetadataResult) obj;
-            return dmr.getId().equals(this.getId()) &&
-            dmr.getName().equals(this.getName()) &&
-            dmr.getCreated().equals(this.getCreated()) &&
-            dmr.getLastUpdated().equals(this.getLastUpdated()) &&
-            dmr.getAssociationType().equals(this.getAssociationType()) &&
-            java.util.Arrays.equals(dmr.getVisibleToUsers(), this.getVisibleToUsers()) &&
-            java.util.Arrays.equals(dmr.getVisibleToGroups(), this.getVisibleToGroups());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DocumentMetadataResult;
 });
 
 foreigner_class!(
@@ -1194,30 +652,8 @@ class DocumentEncryptResult{
     method DocumentAccessChange::changed(&self) -> SucceededResult; alias getChanged;
     /// Get the users and groups whose access failed to be modified
     method DocumentAccessChange::errors(&self) -> FailedResult; alias getErrors;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return this.getId().hashCode() * this.getName().hashCode() * java.util.Arrays.hashCode(this.getEncryptedData()) * 
-        this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
-        this.getChanged().hashCode() * this.getErrors().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DocumentEncryptResult){
-            DocumentEncryptResult der = (DocumentEncryptResult) obj;
-            return der.getId().equals(this.getId()) &&
-            der.getName().equals(this.getName()) &&
-            java.util.Arrays.equals(der.getEncryptedData(), this.getEncryptedData()) &&
-            der.getCreated().equals(this.getCreated()) &&
-            der.getLastUpdated().equals(this.getLastUpdated()) &&
-            der.getChanged().equals(this.getChanged()) &&
-            der.getErrors().equals(this.getErrors());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DocumentEncryptResult;
 });
 
 foreigner_class!(
@@ -1234,27 +670,8 @@ class DocumentEncryptUnmanagedResult {
     method DocumentAccessChange::changed(&self) -> SucceededResult; alias getChanged; 
     /// Get the users and groups whose access failed to be modified
     method DocumentAccessChange::errors(&self) -> FailedResult; alias getErrors;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return this.getId().hashCode() * java.util.Arrays.hashCode(this.getEncryptedData()) * 
-        java.util.Arrays.hashCode(this.getEncryptedDeks()) * this.getChanged().hashCode() * this.getErrors().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DocumentEncryptUnmanagedResult){
-            DocumentEncryptUnmanagedResult deur = (DocumentEncryptUnmanagedResult) obj;
-            return deur.getId().equals(this.getId()) &&
-            java.util.Arrays.equals(deur.getEncryptedData(), this.getEncryptedData()) &&
-            java.util.Arrays.equals(deur.getEncryptedDeks(), this.getEncryptedDeks()) &&
-            deur.getChanged().equals(this.getChanged()) &&
-            deur.getErrors().equals(this.getErrors());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DocumentEncryptUnmanagedResult;
 });
 
 foreigner_class!(
@@ -1267,27 +684,8 @@ class DocumentDecryptResult{
     method document_decrypt_result::decrypted_data(&self) -> Vec<i8>; alias getDecryptedData;
     method document_decrypt_result::created(&self) -> DateTime<Utc>; alias getCreated;
     method document_decrypt_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return this.getId().hashCode() * this.getName().hashCode() * java.util.Arrays.hashCode(this.getDecryptedData()) *
-        this.getCreated().hashCode() * this.getLastUpdated().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DocumentDecryptResult){
-            DocumentDecryptResult ddr = (DocumentDecryptResult) obj;
-            return ddr.getId().equals(this.getId()) &&
-            ddr.getName().equals(this.getName()) &&
-            java.util.Arrays.equals(ddr.getDecryptedData(), this.getDecryptedData()) &&
-            ddr.getCreated().equals(this.getCreated()) &&
-            ddr.getLastUpdated().equals(this.getLastUpdated());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DocumentDecryptResult;
 });
 
 foreigner_class!(
@@ -1301,26 +699,9 @@ class DocumentDecryptUnmanagedResult{
     method document_decrypt_unmanaged_result::decrypted_data(&self) -> Vec<i8>; alias getDecryptedData;
     /// User/Group that granted access to the encrypted data. More specifically,
     /// this is the user/group associated with the edek that was chosen and transformed by the webservice.
-    method document_decrypt_unmanaged_result::access_via(&self) -> UserOrGroupJ; alias getAccessViaUserOrGroup;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return this.getId().hashCode() * java.util.Arrays.hashCode(this.getDecryptedData()) *
-        this.getAccessViaUserOrGroup().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DocumentDecryptUnmanagedResult){
-            DocumentDecryptUnmanagedResult ddur = (DocumentDecryptUnmanagedResult) obj;
-            return ddur.getId().equals(this.getId()) &&
-            java.util.Arrays.equals(ddur.getDecryptedData(), this.getDecryptedData()) &&
-            ddur.getAccessViaUserOrGroup().equals(this.getAccessViaUserOrGroup());
-        }
-        return false;
-    }
-"#;
+    method document_decrypt_unmanaged_result::access_via(&self) -> UserOrGroupId; alias getAccessViaUserOrGroup;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DocumentDecryptUnmanagedResult;
 });
 
 foreigner_class!(
@@ -1332,23 +713,9 @@ class SucceededResult {
     method document_access_change_result::SucceededResult::users(&self) -> Vec<UserId>; alias getUsers;
     /// Get list of groups whose access was granted/revoked
     method document_access_change_result::SucceededResult::groups(&self) -> Vec<GroupId>; alias getGroups;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return java.util.Arrays.hashCode(this.getUsers()) * java.util.Arrays.hashCode(this.getGroups());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof SucceededResult){
-            SucceededResult sr = (SucceededResult) obj;
-            return java.util.Arrays.equals(sr.getUsers(), this.getUsers()) &&
-            java.util.Arrays.equals(sr.getGroups(), this.getGroups());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality SucceededResult;
+
 });
 
 foreigner_class!(
@@ -1362,25 +729,9 @@ class FailedResult {
     method document_access_change_result::FailedResult::groups(&self) -> Vec<GroupAccessErr>; alias getGroups;
     /// Utility method to check if the list of failures is empty
     method document_access_change_result::FailedResult::is_empty(&self) -> bool; alias isEmpty;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return java.util.Arrays.hashCode(this.getUsers()) * java.util.Arrays.hashCode(this.getGroups()) *
-        Boolean.hashCode(this.isEmpty());
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof FailedResult){
-            FailedResult fr = (FailedResult) obj;
-            return java.util.Arrays.equals(fr.getUsers(), this.getUsers()) &&
-            java.util.Arrays.equals(fr.getGroups(), this.getGroups()) &&
-            fr.isEmpty() == this.isEmpty();
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality FailedResult;
+
 });
 
 foreigner_class!(
@@ -1393,23 +744,8 @@ class DocumentAccessResult {
     method DocumentAccessChange::changed(&self) -> SucceededResult; alias getChanged;
     /// Get the users and groups whose access failed to be modified
     method DocumentAccessChange::errors(&self) -> FailedResult; alias getErrors;
-    foreigner_code r#"
-    @Override
-    /**
-     * This implementation calls native code, which means it's relatively slow.
-     */
-    public int hashCode() {
-        return this.getChanged().hashCode() * this.getErrors().hashCode();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DocumentAccessResult){
-            DocumentAccessResult dar = (DocumentAccessResult) obj;
-            return dar.getChanged().equals(this.getChanged()) &&
-            dar.getErrors().equals(this.getErrors());
-        }
-        return false;
-    }
-"#;
+    method hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DocumentAccessResult;
 });
 
 foreigner_class!(
@@ -1424,8 +760,7 @@ class PolicyCachingConfig{
     constructor policy_caching_config::create(maxEntries: usize) -> PolicyCachingConfig;
     constructor PolicyCachingConfig::default() -> PolicyCachingConfig;
     method policy_caching_config::get_max_entries(&self) -> usize; alias getMaxEntries;
-    
-    fn hash(&self) -> i32; alias hashCode;
+    method hash(&self) -> i32; alias hashCode;
     pre_build_generate_equality PolicyCachingConfig;
 });
 
@@ -1439,8 +774,7 @@ class IronOxideConfig{
     constructor ironoxide_config::create(policyCaching: &PolicyCachingConfig, sdkOperationTimeout: Option<&Duration>) -> IronOxideConfig;
     method ironoxide_config::get_policy_caching(&self) -> PolicyCachingConfig; alias getPolicyCachingConfig; 
     method ironoxide_config::get_timeout(&self) -> Option<Duration>; alias getSdkOperationTimeout;
-
-    fn hash(&self) -> i32; alias hashCode;
+    method hash(&self) -> i32; alias hashCode;
     pre_build_generate_equality IronOxideConfig;
 });
 
@@ -1452,8 +786,7 @@ class Duration{
     static_method Duration::from_secs(secs: u64) -> Duration; alias fromSecs;
     method duration::get_millis(&self) -> u64; alias getMillis;
     method duration::get_secs(&self) -> u64; alias getSecs;
-
-    fn hash(&self) -> i32; alias hashCode;
+    method hash(&self) -> i32; alias hashCode;
     pre_build_generate_equality Duration;
 });
 

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -17,8 +17,7 @@ class PublicKey {
     private constructor = empty;
     static_method public_key::validate(bytes: &[i8]) -> Result<PublicKey, String>;
     method public_key::as_bytes(&self) -> Vec<i8>; alias asBytes;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality PublicKey;
+    pre_build_generate_equals_and_hashcode PublicKey;
 });
 
 foreigner_class!(
@@ -29,8 +28,7 @@ class PrivateKey {
     private constructor = empty;
     static_method private_key::validate(bytes: &[i8]) -> Result<PrivateKey, String>;
     method private_key::as_bytes(&self) -> Vec<i8>; alias asBytes;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality PrivateKey;
+    pre_build_generate_equals_and_hashcode PrivateKey;
 });
 
 foreigner_class!(
@@ -41,8 +39,7 @@ class DeviceSigningKeyPair {
     private constructor = empty;
     static_method device_signing_keys::validate(bytes: &[i8]) -> Result<DeviceSigningKeyPair, String>;
     method device_signing_keys::as_bytes(&self) -> Vec<i8>; alias asBytes;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DeviceSigningKeyPair;
+    pre_build_generate_equals_and_hashcode DeviceSigningKeyPair;
 });
 
 foreigner_class!(
@@ -53,8 +50,7 @@ class UserId {
     private constructor = empty;
     static_method user_id::validate(s: &str) -> Result<UserId, String>;
     method user_id::id(&self) -> String; alias getId;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality UserId;
+    pre_build_generate_equals_and_hashcode UserId;
 });
 
 foreigner_class!(
@@ -65,8 +61,7 @@ class GroupId {
     private constructor = empty;
     static_method group_id::validate(s: &str) -> Result<GroupId, String>;
     method group_id::id(&self) -> String; alias getId;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupId;
+    pre_build_generate_equals_and_hashcode GroupId;
 });
 
 foreigner_class!(
@@ -77,8 +72,7 @@ class UserOrGroupId {
     method UserOrGroupId::id(&self) -> String; alias getId;
     method UserOrGroupId::is_user(&self) -> bool; alias isUser;
     method UserOrGroupId::is_group(&self) -> bool; alias isGroup;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality UserOrGroupId;
+    pre_build_generate_equals_and_hashcode UserOrGroupId;
 });
 
 foreigner_class!(
@@ -88,8 +82,7 @@ class GroupName {
     private constructor = empty;
     static_method group_name::validate(s: &str) -> Result<GroupName, String>;
     method group_name::name(&self) -> String; alias getName;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupName;
+    pre_build_generate_equals_and_hashcode GroupName;
 });
 
 foreigner_class!(
@@ -97,8 +90,7 @@ class NullableBoolean{
     self_type NullableBoolean;
     private constructor = empty;
     method NullableBoolean::boolean(&self) -> bool; alias getBoolean;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality NullableBoolean;
+    pre_build_generate_equals_and_hashcode NullableBoolean;
 });
 
 foreigner_class!(
@@ -108,8 +100,7 @@ class DocumentId {
     private constructor = empty;
     static_method document_id::validate(s: &str) -> Result<DocumentId, String>;
     method document_id::id(&self) -> String; alias getId;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DocumentId;
+    pre_build_generate_equals_and_hashcode DocumentId;
 });
 
 foreigner_class!(
@@ -119,8 +110,7 @@ class DocumentName {
     private constructor = empty;
     static_method document_name::validate(s: &str) -> Result<DocumentName, String>;
     method document_name::name(&self) -> String; alias getName;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DocumentName;
+    pre_build_generate_equals_and_hashcode DocumentName;
 });
 
 foreigner_class!(
@@ -130,8 +120,7 @@ class DeviceId {
     private constructor = empty;
     static_method device_id::validate(s: i64) -> Result<DeviceId, String>;
     method device_id::id(&self) -> i64; alias getId;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DeviceId;
+    pre_build_generate_equals_and_hashcode DeviceId;
 });
 
 foreigner_class!(
@@ -142,8 +131,7 @@ foreigner_class!(
         method user_update_private_key_result::user_master_private_key(&self) -> EncryptedPrivateKey; alias getUserMasterPrivateKey;
         /// True if this user's master key requires rotation
         method user_update_private_key_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
-        method hash(&self) -> i32; alias hashCode;
-        pre_build_generate_equality UserUpdatePrivateKeyResult;
+        pre_build_generate_equals_and_hashcode UserUpdatePrivateKeyResult;
 });
 
 foreigner_class!(
@@ -151,8 +139,7 @@ foreigner_class!(
     self_type EncryptedPrivateKey;
     private constructor = empty;
     method encrypted_private_key::as_bytes(&self) -> Vec<i8>; alias asBytes;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality EncryptedPrivateKey;
+    pre_build_generate_equals_and_hashcode EncryptedPrivateKey;
 
 });
 
@@ -163,8 +150,7 @@ class DeviceName {
     private constructor = empty;
     static_method device_name::validate(s: &str) -> Result<DeviceName, String>;
     method device_name::name(&self) -> String; alias getName;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DeviceName;
+    pre_build_generate_equals_and_hashcode DeviceName;
 });
 
 foreigner_class!(
@@ -173,8 +159,7 @@ class VisibleUser {
     self_type VisibleUser;
     private constructor = empty;
     method visible_user::id(&self) -> UserId; alias getId;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality VisibleUser;
+    pre_build_generate_equals_and_hashcode VisibleUser;
 });
 
 foreigner_class!(
@@ -184,8 +169,7 @@ class VisibleGroup {
     private constructor = empty;
     method visible_group::id(&self) -> GroupId; alias getId;
     method visible_group::name(&self) -> Option<GroupName>; alias getName;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality VisibleGroup;
+    pre_build_generate_equals_and_hashcode VisibleGroup;
 });
 
 foreigner_class!(
@@ -195,8 +179,7 @@ class UserAccessErr {
     private constructor = empty;
     method UserAccessErr::id(&self) -> UserId; alias getId;
     method UserAccessErr::err(&self) -> String; alias getErr;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality UserAccessErr;
+    pre_build_generate_equals_and_hashcode UserAccessErr;
 
 });
 
@@ -207,8 +190,7 @@ class GroupAccessErr {
     private constructor = empty;
     method GroupAccessErr::id(&self) -> GroupId; alias getId;
     method GroupAccessErr::err(&self) -> String; alias getErr;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupAccessErr;
+    pre_build_generate_equals_and_hashcode GroupAccessErr;
 
 });
 
@@ -217,8 +199,7 @@ foreigner_class!(class UserWithKey {
     private constructor = empty;
     method UserWithKey::user(&self) -> UserId; alias getUser;
     method UserWithKey::public_key(&self) -> PublicKey; alias getPublicKey;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality UserWithKey;
+    pre_build_generate_equals_and_hashcode UserWithKey;
 
 });
 
@@ -226,8 +207,7 @@ foreigner_class!(class GroupUserList {
     self_type GroupUserList;
     private constructor = empty;
     method GroupUserList::list(&self) -> Vec<UserId>; alias getList;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupUserList;
+    pre_build_generate_equals_and_hashcode GroupUserList;
 
 });
 
@@ -247,8 +227,7 @@ class DeviceContext {
     method device_context::signing_private_key(&self) -> DeviceSigningKeyPair; alias getSigningPrivateKey;
     method device_context::to_json_string(&self) -> String; alias toJsonString;
     static_method device_context::from_json_string(jsonString: &str) -> Result<DeviceContext, String>; alias fromJsonString;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DeviceContext;
+    pre_build_generate_equals_and_hashcode DeviceContext;
 });
 
 foreigner_class!(
@@ -272,8 +251,7 @@ class DeviceAddResult {
     method device_add_result::created(&self) -> DateTime<Utc>; alias getCreated;
     /// The date and time that the device was last updated
     method device_add_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DeviceAddResult;
+    pre_build_generate_equals_and_hashcode DeviceAddResult;
 });
 
 ///
@@ -288,8 +266,7 @@ class UserCreateResult {
     method user_create_result::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
     /// True if the private key of the user's keypair needs to be rotated, else false.
     method user_create_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality UserCreateResult;
+    pre_build_generate_equals_and_hashcode UserCreateResult;
 
 });
 
@@ -302,8 +279,7 @@ class UserResult {
     method user_result::segment_id(&self) -> usize; alias getSegmentId;
     method user_result::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
     method user_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality UserResult;
+    pre_build_generate_equals_and_hashcode UserResult;
 
 });
 
@@ -323,8 +299,7 @@ class UserDevice {
     /// True if this device instance is the one that was used to make
     /// the API request
     method UserDevice::is_current_device(&self) -> bool; alias isCurrentDevice;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality UserDevice;
+    pre_build_generate_equals_and_hashcode UserDevice;
 
 });
 
@@ -333,8 +308,7 @@ foreigner_class!(class DeviceCreateOpts {
     //Construct the DeviceCreateOpts with `null` for name.
     constructor DeviceCreateOpts::default() -> DeviceCreateOpts;
     constructor device_create_opts::create(name: Option<&DeviceName>) -> DeviceCreateOpts;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DeviceCreateOpts;
+    pre_build_generate_equals_and_hashcode DeviceCreateOpts;
 });
 
 foreigner_class!(
@@ -344,8 +318,7 @@ class UserCreateOpts {
     //Construct the UserCreateOpts with a needs_rotation of false.
     constructor UserCreateOpts::default() -> UserCreateOpts;
     constructor user_create_opts::create(needsRotation: bool) -> UserCreateOpts;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality UserCreateOpts;
+    pre_build_generate_equals_and_hashcode UserCreateOpts;
 });
 
 foreigner_class!(
@@ -354,8 +327,7 @@ class UserDeviceListResult {
     self_type UserDeviceListResult;
     private constructor = empty;
     method user_device_list_result::result(&self) -> Vec<UserDevice>; alias getResult;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality UserDeviceListResult;
+    pre_build_generate_equals_and_hashcode UserDeviceListResult;
 
 });
 
@@ -382,8 +354,7 @@ class GroupMetaResult{
     method group_meta_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
     /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
     method group_meta_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupMetaResult;
+    pre_build_generate_equals_and_hashcode GroupMetaResult;
 
 });
 
@@ -414,8 +385,7 @@ class GroupCreateResult{
     method group_create_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
     /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
     method group_create_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupCreateResult;
+    pre_build_generate_equals_and_hashcode GroupCreateResult;
 
 });
 
@@ -423,8 +393,7 @@ foreigner_class!(class GroupListResult{
     self_type GroupListResult;
     private constructor = empty;
     method group_list_result::result(&self) -> Vec<GroupMetaResult>; alias getResult;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupListResult;
+    pre_build_generate_equals_and_hashcode GroupListResult;
 
 });
 
@@ -451,8 +420,7 @@ foreigner_class!(class GroupGetResult{
     method group_get_result::member_list(&self) -> Option<GroupUserList>; alias getMemberList;
     /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
     method group_get_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupGetResult;
+    pre_build_generate_equals_and_hashcode GroupGetResult;
 
 });
 
@@ -465,8 +433,7 @@ class GroupUpdatePrivateKeyResult{
     method group_update_private_key_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
     /// the id of the group whose private key was rotated
     method group_update_private_key_result::id(&self) -> GroupId; alias getId;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupUpdatePrivateKeyResult;
+    pre_build_generate_equals_and_hashcode GroupUpdatePrivateKeyResult;
 
 });
 
@@ -484,8 +451,7 @@ class GroupCreateOpts {
     /// @param members list of users to be added as members of the group. This list takes priority over `addAsMember`, so the creating user will be added as a member even if `addAsMember` is false.
     /// @param needsRotation if true, the group will be marked as needing its private key rotated.
     constructor group_create_opts::create(id: Option<&GroupId>, name: Option<&GroupName>, addAsAdmin: bool, addAsMember: bool, owner: Option<&UserId>, admins: Vec<UserId>, members: Vec<UserId>, needsRotation: bool) -> GroupCreateOpts;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupCreateOpts;
+    pre_build_generate_equals_and_hashcode GroupCreateOpts;
 });
 
 foreigner_class!(
@@ -497,8 +463,7 @@ class GroupAccessEditErr{
     method access_edit_failure::user(&self) -> UserId; alias getUser;
     /// Get the reason for grant/revoke failure
     method access_edit_failure::error(&self) -> String; alias getError;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupAccessEditErr;
+    pre_build_generate_equals_and_hashcode GroupAccessEditErr;
 
 });
 
@@ -511,8 +476,7 @@ class GroupAccessEditResult{
     method group_access_edit_result::succeeded(&self) -> Vec<UserId>; alias getSucceeded;
     /// Get the users whose access could not be modified
     method group_access_edit_result::failed(&self) -> Vec<GroupAccessEditErr>; alias getFailed;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality GroupAccessEditResult;
+    pre_build_generate_equals_and_hashcode GroupAccessEditResult;
 
 });
 
@@ -538,8 +502,7 @@ class Category {
     private constructor = empty;
     static_method category::validate(s: &str) -> Result<Category, String>;
     method category::value(&self) -> String; alias getValue;
-    fn hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality Category;
+    pre_build_generate_equals_and_hashcode Category;
 });
 
 foreigner_class!(
@@ -548,8 +511,7 @@ class Sensitivity {
     private constructor = empty;
     static_method sensitivity::validate(s: &str) -> Result<Sensitivity, String>;
     method sensitivity::value(&self) -> String; alias getValue;
-    fn hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality Sensitivity;
+    pre_build_generate_equals_and_hashcode Sensitivity;
 });
 
 foreigner_class!(
@@ -558,8 +520,7 @@ class DataSubject {
     private constructor = empty;
     static_method data_subject::validate(s: &str) -> Result<DataSubject, String>;
     method data_subject::value(&self) -> String; alias getValue;
-    fn hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DataSubject;
+    pre_build_generate_equals_and_hashcode DataSubject;
 });
 
 foreigner_class!(
@@ -571,8 +532,7 @@ class PolicyGrant {
     method policy_grant::sensitivity(&self) -> Option<Sensitivity>; alias getSensitivity;
     method policy_grant::data_subject(&self) -> Option<DataSubject>; alias getDataSubject;
     method policy_grant::substitute_id(&self) -> Option<UserId>; alias getSubstituteId;
-    fn hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality PolicyGrant;
+    pre_build_generate_equals_and_hashcode PolicyGrant;
 });
 
 foreigner_class!(
@@ -587,8 +547,7 @@ class DocumentEncryptOpts {
     /// @param groupGrants   list of group ids that will be granted access to the document
     /// @param policyGrant   The policy labels which will be evaluated to determine grants. 
     constructor document_create_opt::create(id :Option<&DocumentId>, name :Option<&DocumentName>, grantToAuthor: bool, userGrants: Vec<UserId>, groupGrants: Vec<GroupId>, policyGrant:Option<&PolicyGrant>) -> DocumentEncryptOpts;
-    fn hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DocumentEncryptOpts;
+    pre_build_generate_equals_and_hashcode DocumentEncryptOpts;
 });
 
 foreigner_class!(
@@ -603,8 +562,7 @@ class DocumentListMeta{
     method document_list_meta::association_type(&self) -> AssociationType; alias getAssociationType;
     method document_list_meta::created(&self) -> DateTime<Utc>; alias getCreated;
     method document_list_meta::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DocumentListMeta;
+    pre_build_generate_equals_and_hashcode DocumentListMeta;
 });
 
 foreigner_class!(
@@ -613,8 +571,7 @@ class DocumentListResult{
     self_type DocumentListResult;
     private constructor = empty;
     method document_list_result::result(&self) -> Vec<DocumentListMeta>; alias getResult;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DocumentListResult;
+    pre_build_generate_equals_and_hashcode DocumentListResult;
 });
 
 foreigner_class!(
@@ -629,8 +586,7 @@ class DocumentMetadataResult{
     method document_metadata_result::association_type(&self) -> AssociationType; alias getAssociationType;
     method document_metadata_result::visible_to_users(&self) -> Vec<VisibleUser>; alias getVisibleToUsers;
     method document_metadata_result::visible_to_groups(&self) -> Vec<VisibleGroup>; alias getVisibleToGroups;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DocumentMetadataResult;
+    pre_build_generate_equals_and_hashcode DocumentMetadataResult;
 });
 
 foreigner_class!(
@@ -652,8 +608,7 @@ class DocumentEncryptResult{
     method DocumentAccessChange::changed(&self) -> SucceededResult; alias getChanged;
     /// Get the users and groups whose access failed to be modified
     method DocumentAccessChange::errors(&self) -> FailedResult; alias getErrors;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DocumentEncryptResult;
+    pre_build_generate_equals_and_hashcode DocumentEncryptResult;
 });
 
 foreigner_class!(
@@ -670,8 +625,7 @@ class DocumentEncryptUnmanagedResult {
     method DocumentAccessChange::changed(&self) -> SucceededResult; alias getChanged; 
     /// Get the users and groups whose access failed to be modified
     method DocumentAccessChange::errors(&self) -> FailedResult; alias getErrors;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DocumentEncryptUnmanagedResult;
+    pre_build_generate_equals_and_hashcode DocumentEncryptUnmanagedResult;
 });
 
 foreigner_class!(
@@ -684,8 +638,7 @@ class DocumentDecryptResult{
     method document_decrypt_result::decrypted_data(&self) -> Vec<i8>; alias getDecryptedData;
     method document_decrypt_result::created(&self) -> DateTime<Utc>; alias getCreated;
     method document_decrypt_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DocumentDecryptResult;
+    pre_build_generate_equals_and_hashcode DocumentDecryptResult;
 });
 
 foreigner_class!(
@@ -700,8 +653,7 @@ class DocumentDecryptUnmanagedResult{
     /// User/Group that granted access to the encrypted data. More specifically,
     /// this is the user/group associated with the edek that was chosen and transformed by the webservice.
     method document_decrypt_unmanaged_result::access_via(&self) -> UserOrGroupId; alias getAccessViaUserOrGroup;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DocumentDecryptUnmanagedResult;
+    pre_build_generate_equals_and_hashcode DocumentDecryptUnmanagedResult;
 });
 
 foreigner_class!(
@@ -713,8 +665,7 @@ class SucceededResult {
     method document_access_change_result::SucceededResult::users(&self) -> Vec<UserId>; alias getUsers;
     /// Get list of groups whose access was granted/revoked
     method document_access_change_result::SucceededResult::groups(&self) -> Vec<GroupId>; alias getGroups;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality SucceededResult;
+    pre_build_generate_equals_and_hashcode SucceededResult;
 
 });
 
@@ -729,8 +680,7 @@ class FailedResult {
     method document_access_change_result::FailedResult::groups(&self) -> Vec<GroupAccessErr>; alias getGroups;
     /// Utility method to check if the list of failures is empty
     method document_access_change_result::FailedResult::is_empty(&self) -> bool; alias isEmpty;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality FailedResult;
+    pre_build_generate_equals_and_hashcode FailedResult;
 
 });
 
@@ -744,8 +694,7 @@ class DocumentAccessResult {
     method DocumentAccessChange::changed(&self) -> SucceededResult; alias getChanged;
     /// Get the users and groups whose access failed to be modified
     method DocumentAccessChange::errors(&self) -> FailedResult; alias getErrors;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality DocumentAccessResult;
+    pre_build_generate_equals_and_hashcode DocumentAccessResult;
 });
 
 foreigner_class!(
@@ -760,8 +709,7 @@ class PolicyCachingConfig{
     constructor policy_caching_config::create(maxEntries: usize) -> PolicyCachingConfig;
     constructor PolicyCachingConfig::default() -> PolicyCachingConfig;
     method policy_caching_config::get_max_entries(&self) -> usize; alias getMaxEntries;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality PolicyCachingConfig;
+    pre_build_generate_equals_and_hashcode PolicyCachingConfig;
 });
 
 foreigner_class!(
@@ -774,8 +722,7 @@ class IronOxideConfig{
     constructor ironoxide_config::create(policyCaching: &PolicyCachingConfig, sdkOperationTimeout: Option<&Duration>) -> IronOxideConfig;
     method ironoxide_config::get_policy_caching(&self) -> PolicyCachingConfig; alias getPolicyCachingConfig; 
     method ironoxide_config::get_timeout(&self) -> Option<Duration>; alias getSdkOperationTimeout;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality IronOxideConfig;
+    pre_build_generate_equals_and_hashcode IronOxideConfig;
 });
 
 foreigner_class!(
@@ -786,8 +733,7 @@ class Duration{
     static_method Duration::from_secs(secs: u64) -> Duration; alias fromSecs;
     method duration::get_millis(&self) -> u64; alias getMillis;
     method duration::get_secs(&self) -> u64; alias getSecs;
-    method hash(&self) -> i32; alias hashCode;
-    pre_build_generate_equality Duration;
+    pre_build_generate_equals_and_hashcode Duration;
 });
 
 ///

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -95,21 +95,8 @@ class UserId {
     private constructor = empty;
     static_method user_id::validate(s: &str) -> Result<UserId, String>;
     method user_id::id(&self) -> String; alias getId;
-    
-    private fn hash(&self) -> i16; alias rustHash;
-    private fn eq(&self, o: &UserId) -> bool; alias rustEq;
-    foreign_code r#"
-    public int hashCode() {
-        return this.rustHash();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof UserId){
-            UserId other = (UserId) obj;
-            return other.rustEq(this);
-        }
-        return false;
-    }
-"#;
+    fn hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality UserId;
 });
 
 foreigner_class!(
@@ -121,20 +108,8 @@ class GroupId {
     static_method group_id::validate(s: &str) -> Result<GroupId, String>;
     method group_id::id(&self) -> String; alias getId;
 
-    private fn hash(&self) -> i16; alias rustHash;
-    private fn eq(&self, o: &GroupId) -> bool; alias rustEq;
-    foreign_code r#"
-    public int hashCode() {
-        return this.rustHash();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof GroupId){
-            GroupId other = (GroupId) obj;
-            return other.rustEq(this);
-        }
-        return false;
-    }
-"#;
+    fn hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality GroupId;
 });
 
 foreigner_class!(
@@ -1047,20 +1022,8 @@ class Category {
     static_method category::validate(s: &str) -> Result<Category, String>;
     method category::value(&self) -> String; alias getValue;
     
-    private fn hash(&self) -> i16; alias rustHash;
-    private fn eq(&self, o: &Category) -> bool; alias rustEq;
-    foreign_code r#"
-    public int hashCode() {
-        return this.rustHash();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof Category){
-            Category other = (Category) obj;
-            return other.rustEq(this);
-        }
-        return false;
-    }
-"#;
+    fn hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality Category;
 });
 
 foreigner_class!(
@@ -1070,20 +1033,8 @@ class Sensitivity {
     static_method sensitivity::validate(s: &str) -> Result<Sensitivity, String>;
     method sensitivity::value(&self) -> String; alias getValue;
     
-    private fn hash(&self) -> i16; alias rustHash;
-    private fn eq(&self, o: &Sensitivity) -> bool; alias rustEq;
-    foreign_code r#"
-    public int hashCode() {
-        return this.rustHash();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof Sensitivity){
-            Sensitivity other = (Sensitivity) obj;
-            return other.rustEq(this);
-        }
-        return false;
-    }
-"#;
+    fn hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality Sensitivity;
 });
 
 foreigner_class!(
@@ -1093,20 +1044,8 @@ class DataSubject {
     static_method data_subject::validate(s: &str) -> Result<DataSubject, String>;
     method data_subject::value(&self) -> String; alias getValue;
     
-    private fn hash(&self) -> i16; alias rustHash;
-    private fn eq(&self, o: &DataSubject) -> bool; alias rustEq;
-    foreign_code r#"
-    public int hashCode() {
-        return this.rustHash();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof DataSubject){
-            DataSubject other = (DataSubject) obj;
-            return other.rustEq(this);
-        }
-        return false;
-    }
-"#;
+    fn hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality DataSubject;
 });
 
 foreigner_class!(
@@ -1119,20 +1058,8 @@ class PolicyGrant {
     method policy_grant::data_subject(&self) -> Option<DataSubject>; alias getDataSubject;
     method policy_grant::substitute_id(&self) -> Option<UserId>; alias getSubstituteId;
     
-    private fn hash(&self) -> i16; alias rustHash;
-    private fn eq(&self, o: &PolicyGrant) -> bool; alias rustEq;
-    foreign_code r#"
-    public int hashCode() {
-        return this.rustHash();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof PolicyGrant){
-            PolicyGrant other = (PolicyGrant) obj;
-            return other.rustEq(this);
-        }
-        return false;
-    }
-"#;
+    fn hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality PolicyGrant;
 });
 
 foreigner_class!(
@@ -1498,20 +1425,8 @@ class PolicyCachingConfig{
     constructor PolicyCachingConfig::default() -> PolicyCachingConfig;
     method policy_caching_config::get_max_entries(&self) -> usize; alias getMaxEntries;
     
-    private fn hash(&self) -> i16; alias rustHash;
-    private fn eq(&self, o: &PolicyCachingConfig) -> bool; alias rustEq;
-    foreigner_code r#"
-    public int hashCode() {
-        return this.rustHash();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof PolicyCachingConfig){
-            PolicyCachingConfig other = (PolicyCachingConfig) obj;
-            return other.rustEq(this);
-        }
-        return false;
-    }
-"#;
+    fn hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality PolicyCachingConfig;
 });
 
 foreigner_class!(
@@ -1525,20 +1440,8 @@ class IronOxideConfig{
     method ironoxide_config::get_policy_caching(&self) -> PolicyCachingConfig; alias getPolicyCachingConfig; 
     method ironoxide_config::get_timeout(&self) -> Option<Duration>; alias getSdkOperationTimeout;
 
-    private fn hash(&self) -> i16; alias rustHash;
-    private fn eq(&self, o: &IronOxideConfig) -> bool; alias rustEq;
-    foreign_code r#"
-    public int hashCode() {
-        return this.rustHash();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof IronOxideConfig){
-            IronOxideConfig other = (IronOxideConfig) obj;
-            return other.rustEq(this);
-        }
-        return false;
-    }
-"#;
+    fn hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality IronOxideConfig;
 });
 
 foreigner_class!(
@@ -1550,20 +1453,8 @@ class Duration{
     method duration::get_millis(&self) -> u64; alias getMillis;
     method duration::get_secs(&self) -> u64; alias getSecs;
 
-    private fn hash(&self) -> i16; alias rustHash;
-    private fn eq(&self, o: &Duration) -> bool; alias rustEq;
-    foreign_code r#"
-    public int hashCode() {
-        return this.rustHash();
-    }
-    public boolean equals(Object obj) {
-        if(obj instanceof Duration){
-            Duration other = (Duration) obj;
-            return other.rustEq(this);
-        }
-        return false;
-    }
-"#;
+    fn hash(&self) -> i32; alias hashCode;
+    pre_build_generate_equality Duration;
 });
 
 ///

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -716,14 +716,13 @@ foreigner_class!(class DeviceCreateOpts {
 });
 
 foreigner_class!(
-    /// Options that can be specified creating a user.
-    class UserCreateOpts {
-        self_type UserCreateOpts;
-        //Construct the UserCreateOpts with a needs_rotation of false.
-        constructor UserCreateOpts::default() -> UserCreateOpts;
-        static_method user_create_opts::create(needsRotation: bool) -> UserCreateOpts;
-    }
-);
+/// Options that can be specified creating a user.
+class UserCreateOpts {
+    self_type UserCreateOpts;
+    //Construct the UserCreateOpts with a needs_rotation of false.
+    constructor UserCreateOpts::default() -> UserCreateOpts;
+    static_method user_create_opts::create(needsRotation: bool) -> UserCreateOpts;
+});
 
 foreigner_class!(
 /// Devices for a user, sorted by the device id.
@@ -731,6 +730,22 @@ class UserDeviceListResult {
     self_type UserDeviceListResult;
     private constructor = empty;
     method user_device_list_result::result(&self) -> Vec<UserDevice>; alias getResult;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getResult().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof UserDeviceListResult){
+            UserDeviceListResult udlr = (UserDeviceListResult) obj;
+            return java.util.Arrays.equals(udlr.getResult(), this.getResult());
+        }
+        return false;
+    }
+"#;
 });
 
 ///
@@ -756,41 +771,112 @@ class GroupMetaResult{
     method group_meta_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
     /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
     method group_meta_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode() * this.getName().hashCode() *
+        Boolean.hashCode(this.isAdmin()) * Boolean.hashCode(this.isMember()) *
+        this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
+        this.getNeedsRotation().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof GroupMetaResult){
+            GroupMetaResult gmr = (GroupMetaResult) obj;
+            return gmr.getId().equals(this.getId()) && 
+            gmr.getName().equals(this.getName()) &&
+            gmr.isAdmin() == this.isAdmin() &&
+            gmr.isMember() == this.isMember() &&
+            gmr.getCreated().equals(this.getCreated()) &&
+            gmr.getLastUpdated().equals(this.getLastUpdated()) &&
+            gmr.getNeedsRotation().equals(this.getNeedsRotation());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
-    /// Group information from creation.
-    class GroupCreateResult{
-        self_type GroupCreateResult;
-        private constructor = empty;
-        /// get the unique id of the group 
-        method group_create_result::id(&self) -> GroupId; alias getId;
-        /// null if the group has no name, else the group's name
-        method group_create_result::name(&self) -> Option<GroupName>; alias getName;
-        /// public key for encrypting to the group
-        method group_create_result::group_master_public_key(&self) -> PublicKey; alias getGroupMasterPublicKey;
-        /// true if the calling user is a group admin
-        method GroupCreateResult::is_admin(&self) -> bool; alias isAdmin;
-        /// true if the calling user is a group member
-        method GroupCreateResult::is_member(&self) -> bool; alias isMember;
-        /// owner of the group
-        method group_create_result::owner(&self) -> UserId; alias getOwner; 
-        /// a GroupUserList of group admins. Group admins can change group membership.
-        method group_create_result::admin_list(&self) -> GroupUserList; alias getAdminList;
-        /// a GroupUserList of group members. Members of a group can decrypt values encrypted to the group.
-        method group_create_result::member_list(&self) -> GroupUserList; alias getMemberList;
-        /// date and time that the group was created
-        method group_create_result::created(&self) -> DateTime<Utc>; alias getCreated;
-        /// date and time that the group was last updated
-        method group_create_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
-        /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
-        method group_create_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
-    });
+/// Group information from creation.
+class GroupCreateResult{
+    self_type GroupCreateResult;
+    private constructor = empty;
+    /// get the unique id of the group 
+    method group_create_result::id(&self) -> GroupId; alias getId;
+    /// null if the group has no name, else the group's name
+    method group_create_result::name(&self) -> Option<GroupName>; alias getName;
+    /// public key for encrypting to the group
+    method group_create_result::group_master_public_key(&self) -> PublicKey; alias getGroupMasterPublicKey;
+    /// true if the calling user is a group admin
+    method GroupCreateResult::is_admin(&self) -> bool; alias isAdmin;
+    /// true if the calling user is a group member
+    method GroupCreateResult::is_member(&self) -> bool; alias isMember;
+    /// owner of the group
+    method group_create_result::owner(&self) -> UserId; alias getOwner; 
+    /// a GroupUserList of group admins. Group admins can change group membership.
+    method group_create_result::admin_list(&self) -> GroupUserList; alias getAdminList;
+    /// a GroupUserList of group members. Members of a group can decrypt values encrypted to the group.
+    method group_create_result::member_list(&self) -> GroupUserList; alias getMemberList;
+    /// date and time that the group was created
+    method group_create_result::created(&self) -> DateTime<Utc>; alias getCreated;
+    /// date and time that the group was last updated
+    method group_create_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
+    /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
+    method group_create_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode() * this.getName().hashCode() * this.getGroupMasterPublicKey().hashCode() *
+        Boolean.hashCode(this.isAdmin()) * Boolean.hashCode(this.isMember()) * this.getOwner().hashCode() *
+        this.getAdminList().hashCode() * this.getMemberList().hashCode() *
+        this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
+        this.getNeedsRotation().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof GroupCreateResult){
+            GroupCreateResult gcr = (GroupCreateResult) obj;
+            return gcr.getId().equals(this.getId()) && 
+            gcr.getName().equals(this.getName()) &&
+            gcr.getGroupMasterPublicKey().equals(this.getGroupMasterPublicKey()) &&
+            gcr.isAdmin() == this.isAdmin() &&
+            gcr.isMember() == this.isMember() &&
+            gcr.getOwner().equals(this.getOwner()) &&
+            gcr.getAdminList().equals(this.getAdminList()) &&
+            gcr.getMemberList().equals(this.getMemberList()) &&
+            gcr.getCreated().equals(this.getCreated()) &&
+            gcr.getLastUpdated().equals(this.getLastUpdated()) &&
+            gcr.getNeedsRotation().equals(this.getNeedsRotation());
+        }
+        return false;
+    }
+"#;
+});
 
 foreigner_class!(class GroupListResult{
     self_type GroupListResult;
     private constructor = empty;
     method group_list_result::result(&self) -> Vec<GroupMetaResult>; alias getResult;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getResult().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof GroupListResult){
+            GroupListResult glr = (GroupListResult) obj;
+            return java.util.Arrays.equals(glr.getResult(), this.getResult());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(class GroupGetResult{
@@ -816,6 +902,35 @@ foreigner_class!(class GroupGetResult{
     method group_get_result::member_list(&self) -> Option<GroupUserList>; alias getMemberList;
     /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
     method group_get_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
+    foreigner_code r#"
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode() * this.getName().hashCode() * this.getGroupMasterPublicKey().hashCode() *
+        Boolean.hashCode(this.isAdmin()) * Boolean.hashCode(this.isMember()) *
+        this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
+        this.getAdminList().hashCode() * this.getMemberList().hashCode() *
+        this.getNeedsRotation().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof GroupCreateResult){
+            GroupCreateResult gcr = (GroupCreateResult) obj;
+            return gcr.getId().equals(this.getId()) && 
+            gcr.getName().equals(this.getName()) &&
+            gcr.getGroupMasterPublicKey().equals(this.getGroupMasterPublicKey()) &&
+            gcr.isAdmin() == this.isAdmin() &&
+            gcr.isMember() == this.isMember() &&
+            gcr.getCreated().equals(this.getCreated()) &&
+            gcr.getLastUpdated().equals(this.getLastUpdated()) &&
+            gcr.getAdminList().equals(this.getAdminList()) &&
+            gcr.getMemberList().equals(this.getMemberList()) &&
+            gcr.getNeedsRotation().equals(this.getNeedsRotation());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(class GroupUpdatePrivateKeyResult{
@@ -825,6 +940,23 @@ foreigner_class!(class GroupUpdatePrivateKeyResult{
     method group_update_private_key_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
     /// the id of the group whose private key was rotated
     method group_update_private_key_result::id(&self) -> GroupId; alias getId;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getId().hashCode() * Boolean.hashCode(this.getNeedsRotation());
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof GroupUpdatePrivateKeyResult){
+            GroupUpdatePrivateKeyResult gupkr = (GroupUpdatePrivateKeyResult) obj;
+            return gupkr.getId().equals(this.getId()) && 
+            gupkr.getNeedsRotation() == this.getNeedsRotation();
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -852,6 +984,23 @@ class GroupAccessEditErr{
     method access_edit_failure::user(&self) -> UserId; alias getUser;
     /// Get the reason for grant/revoke failure
     method access_edit_failure::error(&self) -> String; alias getError;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getUser().hashCode() * this.getError().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof GroupAccessEditErr){
+            GroupAccessEditErr gaee = (GroupAccessEditErr) obj;
+            return gaee.getUser().equals(this.getUser()) && 
+            gaee.getError().equals(this.getError());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -863,6 +1012,23 @@ class GroupAccessEditResult{
     method group_access_edit_result::succeeded(&self) -> Vec<UserId>; alias getSucceeded;
     /// Get the users whose access could not be modified
     method group_access_edit_result::failed(&self) -> Vec<GroupAccessEditErr>; alias getFailed;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getSucceeded().hashCode() * this.getFailed().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof GroupAccessEditResult){
+            GroupAccessEditResult gaer = (GroupAccessEditResult) obj;
+            return java.util.Arrays.equals(gaer.getSucceeded(), this.getSucceeded()) && 
+            java.util.Arrays.equals(gaer.getFailed(), this.getFailed());
+        }
+        return false;
+    }
+"#;
 });
 
 ///
@@ -886,7 +1052,23 @@ class Category {
     self_type Category;
     private constructor = empty;
     static_method category::validate(s: &str) -> Result<Category, String>;
-    method category::value(&self) -> String;
+    method category::value(&self) -> String; alias getValue;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getValue().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof Category){
+            Category cat = (Category) obj;
+            return cat.getValue().equals(this.getValue());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -894,7 +1076,23 @@ class Sensitivity {
     self_type Sensitivity;
     private constructor = empty;
     static_method sensitivity::validate(s: &str) -> Result<Sensitivity, String>;
-    method sensitivity::value(&self) -> String;
+    method sensitivity::value(&self) -> String; alias getValue;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getValue().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof Sensitivity){
+            Sensitivity sen = (Sensitivity) obj;
+            return sen.getValue().equals(this.getValue());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -902,7 +1100,23 @@ class DataSubject {
     self_type DataSubject;
     private constructor = empty;
     static_method data_subject::validate(s: &str) -> Result<DataSubject, String>;
-    method data_subject::value(&self) -> String;
+    method data_subject::value(&self) -> String; alias getValue;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getValue().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DataSubject){
+            DataSubject sub = (DataSubject) obj;
+            return sub.getValue().equals(this.getValue());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -910,10 +1124,30 @@ class PolicyGrant {
     self_type PolicyGrant;
     constructor PolicyGrant::default() -> PolicyGrant;
     constructor policy_grant::create(category:Option<&Category>,sensitivity:Option<&Sensitivity>,dataSubject:Option<&DataSubject>,substituteUser:Option<&UserId>) -> PolicyGrant;
-    method policy_grant::category(&self) -> Option<Category>;
-    method policy_grant::sensitivity(&self) -> Option<Sensitivity>;
-    method policy_grant::data_subject(&self) -> Option<DataSubject>; alias dataSubject;
-    method policy_grant::substitute_id(&self) -> Option<UserId>; alias substituteId;
+    method policy_grant::category(&self) -> Option<Category>; alias getCategory;
+    method policy_grant::sensitivity(&self) -> Option<Sensitivity>; alias getSensitivity;
+    method policy_grant::data_subject(&self) -> Option<DataSubject>; alias getDataSubject;
+    method policy_grant::substitute_id(&self) -> Option<UserId>; alias getSubstituteId;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getCategory().hashCode() * this.getSensitivity().hashCode() *
+        this.getDataSubject().hashCode() * this.getSubstituteId().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof PolicyGrant){
+            PolicyGrant pg = (PolicyGrant) obj;
+            return pg.getCategory().equals(this.getCategory()) &&
+            pg.getSensitivity().equals(this.getSensitivity()) &&
+            pg.getDataSubject().equals(this.getDataSubject()) &&
+            pg.getSubstituteId().equals(this.getSubstituteId());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -942,6 +1176,28 @@ class DocumentListMeta{
     method document_list_meta::association_type(&self) -> AssociationType; alias getAssociationType;
     method document_list_meta::created(&self) -> DateTime<Utc>; alias getCreated;
     method document_list_meta::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getId().hashCode() * this.getName().hashCode() *
+        this.getAssociationType().hashCode() * this.getCreated().hashCode() *
+        this.getLastUpdated().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DocumentListMeta){
+            DocumentListMeta dlm = (DocumentListMeta) obj;
+            return dlm.getId().equals(this.getId()) &&
+            dlm.getName().equals(this.getName()) &&
+            dlm.getAssociationType().equals(this.getAssociationType()) &&
+            dlm.getCreated().equals(this.getCreated()) &&
+            dlm.getLastUpdated().equals(this.getLastUpdated());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -950,6 +1206,22 @@ class DocumentListResult{
     self_type DocumentListResult;
     private constructor = empty;
     method document_list_result::result(&self) -> Vec<DocumentListMeta>; alias getResult;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getResult().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DocumentListResult){
+            DocumentListResult dlr = (DocumentListResult) obj;
+            return java.util.Arrays.equals(dlr.getResult(), this.getResult());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -964,6 +1236,31 @@ class DocumentMetadataResult{
     method document_metadata_result::association_type(&self) -> AssociationType; alias getAssociationType;
     method document_metadata_result::visible_to_users(&self) -> Vec<VisibleUser>; alias getVisibleToUsers;
     method document_metadata_result::visible_to_groups(&self) -> Vec<VisibleGroup>; alias getVisibleToGroups;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getId().hashCode() * this.getName().hashCode() *
+        this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
+        this.getAssociationType().hashCode() * this.getVisibleToUsers().hashCode() *
+        this.getVisibleToGroups().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DocumentMetadataResult){
+            DocumentMetadataResult dmr = (DocumentMetadataResult) obj;
+            return dmr.getId().equals(this.getId()) &&
+            dmr.getName().equals(this.getName()) &&
+            dmr.getCreated().equals(this.getCreated()) &&
+            dmr.getLastUpdated().equals(this.getLastUpdated()) &&
+            dmr.getAssociationType().equals(this.getAssociationType()) &&
+            java.util.Arrays.equals(dmr.getVisibleToUsers(), this.getVisibleToUsers()) &&
+            java.util.Arrays.equals(dmr.getVisibleToGroups(), this.getVisibleToGroups());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -985,6 +1282,30 @@ class DocumentEncryptResult{
     method DocumentAccessChange::changed(&self) -> SucceededResult; alias getChanged;
     /// Get the users and groups whose access failed to be modified
     method DocumentAccessChange::errors(&self) -> FailedResult; alias getErrors;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getId().hashCode() * this.getName().hashCode() * this.getEncryptedData().hashCode() * 
+        this.getCreated().hashCode() * this.getLastUpdated().hashCode() *
+        this.getChanged().hashCode() * this.getErrors().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DocumentEncryptResult){
+            DocumentEncryptResult der = (DocumentEncryptResult) obj;
+            return der.getId().equals(this.getId()) &&
+            der.getName().equals(this.getName()) &&
+            java.util.Arrays.equals(der.getEncryptedData(), this.getEncryptedData()) &&
+            der.getCreated().equals(this.getCreated()) &&
+            der.getLastUpdated().equals(this.getLastUpdated()) &&
+            der.getChanged().equals(this.getChanged()) &&
+            der.getErrors().equals(this.getErrors());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -1001,8 +1322,28 @@ class DocumentEncryptUnmanagedResult {
     method DocumentAccessChange::changed(&self) -> SucceededResult; alias getChanged; 
     /// Get the users and groups whose access failed to be modified
     method DocumentAccessChange::errors(&self) -> FailedResult; alias getErrors;
-}
-);
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getId().hashCode() * this.getEncryptedData().hashCode() * this.getEncryptedDeks().hashCode() *
+        this.getChanged().hashCode() * this.getErrors().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DocumentEncryptUnmanagedResult){
+            DocumentEncryptUnmanagedResult deur = (DocumentEncryptUnmanagedResult) obj;
+            return deur.getId().equals(this.getId()) &&
+            java.util.Arrays.equals(deur.getEncryptedData(), this.getEncryptedData()) &&
+            java.util.Arrays.equals(deur.getEncryptedDeks(), this.getEncryptedDeks()) &&
+            deur.getChanged().equals(this.getChanged()) &&
+            deur.getErrors().equals(this.getErrors());
+        }
+        return false;
+    }
+"#;
+});
 
 foreigner_class!(
 /// Result of decrypting a document. Includes minimal metadata as well as the decrypted bytes.
@@ -1014,6 +1355,27 @@ class DocumentDecryptResult{
     method document_decrypt_result::decrypted_data(&self) -> Vec<i8>; alias getDecryptedData;
     method document_decrypt_result::created(&self) -> DateTime<Utc>; alias getCreated;
     method document_decrypt_result::last_updated(&self) -> DateTime<Utc>; alias getLastUpdated;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getId().hashCode() * this.getName().hashCode() * this.getDecryptedData().hashCode() *
+        this.getCreated().hashCode() * this.getLastUpdated().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DocumentDecryptResult){
+            DocumentDecryptResult ddr = (DocumentDecryptResult) obj;
+            return ddr.getId().equals(this.getId()) &&
+            ddr.getName().equals(this.getName()) &&
+            java.util.Arrays.equals(ddr.getDecryptedData(), this.getDecryptedData()) &&
+            ddr.getCreated().equals(this.getCreated()) &&
+            ddr.getLastUpdated().equals(this.getLastUpdated());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -1028,6 +1390,25 @@ class DocumentDecryptUnmanagedResult{
     /// User/Group that granted access to the encrypted data. More specifically,
     /// this is the user/group associated with the edek that was chosen and transformed by the webservice.
     method document_decrypt_unmanaged_result::access_via(&self) -> UserOrGroupJ; alias getAccessViaUserOrGroup;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getId().hashCode() * this.getDecryptedData().hashCode() *
+        this.getAccessViaUserOrGroup().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DocumentDecryptUnmanagedResult){
+            DocumentDecryptUnmanagedResult ddur = (DocumentDecryptUnmanagedResult) obj;
+            return ddur.getId().equals(this.getId()) &&
+            java.util.Arrays.equals(ddur.getDecryptedData(), this.getDecryptedData()) &&
+            ddur.getAccessViaUserOrGroup().equals(this.getAccessViaUserOrGroup());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -1035,11 +1416,27 @@ foreigner_class!(
 class SucceededResult {
     self_type SucceededResult;
     private constructor = empty;
-
     /// Get list of users whose access was granted/revoked
     method document_access_change_result::SucceededResult::users(&self) -> Vec<UserId>; alias getUsers;
     /// Get list of groups whose access was granted/revoked
     method document_access_change_result::SucceededResult::groups(&self) -> Vec<GroupId>; alias getGroups;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getUsers().hashCode() * this.getGroups().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof SucceededResult){
+            SucceededResult sr = (SucceededResult) obj;
+            return java.util.Arrays.equals(sr.getUsers(), this.getUsers()) &&
+            java.util.Arrays.equals(sr.getGroups(), this.getGroups());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -1047,14 +1444,31 @@ foreigner_class!(
 class FailedResult {
     self_type FailedResult;
     private constructor = empty;
-
     /// Get list of users whose access was to be granted/revoked
     method document_access_change_result::FailedResult::users(&self) -> Vec<UserAccessErr>; alias getUsers;
     /// Get list of groups whose access was to be granted/revoked
     method document_access_change_result::FailedResult::groups(&self) -> Vec<GroupAccessErr>; alias getGroups;
     /// Utility method to check if the list of failures is empty
     method document_access_change_result::FailedResult::is_empty(&self) -> bool; alias isEmpty;
-
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getUsers().hashCode() * this.getGroups().hashCode() *
+        Boolean.hashCode(this.isEmpty());
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof FailedResult){
+            FailedResult fr = (FailedResult) obj;
+            return java.util.Arrays.equals(fr.getUsers(), this.getUsers()) &&
+            java.util.Arrays.equals(fr.getGroups(), this.getGroups()) &&
+            fr.isEmpty() == this.isEmpty();
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -1063,11 +1477,27 @@ foreigner_class!(
 class DocumentAccessResult {
     self_type DocumentAccessResult;
     private constructor = empty;
-
     /// Get the users and groups whose access was successfully changed
     method DocumentAccessChange::changed(&self) -> SucceededResult; alias getChanged;
     /// Get the users and groups whose access failed to be modified
     method DocumentAccessChange::errors(&self) -> FailedResult; alias getErrors;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getChanged().hashCode() * this.getErrors().hashCode();
+    }
+    public boolean equals(Object obj) {
+        if(obj instanceof DocumentAccessResult){
+            DocumentAccessResult dar = (DocumentAccessResult) obj;
+            return dar.getChanged().equals(this.getChanged()) &&
+            dar.getErrors().equals(this.getErrors());
+        }
+        return false;
+    }
+"#;
 });
 
 foreigner_class!(
@@ -1075,39 +1505,85 @@ foreigner_class!(
 /// 
 /// Since policies are evaluated by the webservice, caching the result can greatly speed
 /// up encrypting a document with a PolicyGrant.
-    class PolicyCachingConfig{
-        self_type PolicyCachingConfig;
-        /// @param maxEntries  maximum number of policy evaluations that will be cached by the SDK.
-        ///                    If the maximum number is exceeded, the cache will be cleared prior to storing the next entry.
-        constructor policy_caching_config::create(maxEntries: usize) -> PolicyCachingConfig;
-        constructor PolicyCachingConfig::default() -> PolicyCachingConfig;
-        method policy_caching_config::get_max_entries(&self) -> usize; alias getMaxEntries;
+class PolicyCachingConfig{
+    self_type PolicyCachingConfig;
+    /// @param maxEntries  maximum number of policy evaluations that will be cached by the SDK.
+    ///                    If the maximum number is exceeded, the cache will be cleared prior to storing the next entry.
+    constructor policy_caching_config::create(maxEntries: usize) -> PolicyCachingConfig;
+    constructor PolicyCachingConfig::default() -> PolicyCachingConfig;
+    method policy_caching_config::get_max_entries(&self) -> usize; alias getMaxEntries;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return Long.hashCode(this.getMaxEntries());
     }
-);
+    public boolean equals(Object obj) {
+        if(obj instanceof PolicyCachingConfig){
+            PolicyCachingConfig pcc = (PolicyCachingConfig) obj;
+            return pcc.getMaxEntries() == this.getMaxEntries();
+        }
+        return false;
+    }
+"#;
+});
 
 foreigner_class!(
 /// Top-level configuration object for IronOxide
-    class IronOxideConfig{
-        self_type IronOxideConfig;
-        constructor IronOxideConfig::default() -> IronOxideConfig;
-        /// @param policyCaching        policy caching configuration for IronOxide
-        /// @param sdkOperationTimeout  timeout for all SDK methods
-        constructor ironoxide_config::create(policyCaching: &PolicyCachingConfig, sdkOperationTimeout: Option<&Duration>) -> IronOxideConfig;
-        method ironoxide_config::get_policy_caching(&self) -> PolicyCachingConfig; alias getPolicyCachingConfig; 
-        method ironoxide_config::get_timeout(&self) -> Option<Duration>; alias getSdkOperationTimeout;
+class IronOxideConfig{
+    self_type IronOxideConfig;
+    constructor IronOxideConfig::default() -> IronOxideConfig;
+    /// @param policyCaching        policy caching configuration for IronOxide
+    /// @param sdkOperationTimeout  timeout for all SDK methods
+    constructor ironoxide_config::create(policyCaching: &PolicyCachingConfig, sdkOperationTimeout: Option<&Duration>) -> IronOxideConfig;
+    method ironoxide_config::get_policy_caching(&self) -> PolicyCachingConfig; alias getPolicyCachingConfig; 
+    method ironoxide_config::get_timeout(&self) -> Option<Duration>; alias getSdkOperationTimeout;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return this.getPolicyCachingConfig().hashCode() * this.getSdkOperationTimeout().hashCode();
     }
-);
+    public boolean equals(Object obj) {
+        if(obj instanceof IronOxideConfig){
+            IronOxideConfig ioc = (IronOxideConfig) obj;
+            return ioc.getPolicyCachingConfig().equals(this.getPolicyCachingConfig()) &&
+            ioc.getSdkOperationTimeout().equals(this.getSdkOperationTimeout());
+        }
+        return false;
+    }
+"#;
+});
 
 foreigner_class!(
-    class Duration{
-        self_type Duration;
-        private constructor = empty;
-        static_method Duration::from_millis(millis: u64) -> Duration;
-        static_method Duration::from_secs(secs: u64) -> Duration;
-        method duration::get_millis(&self) -> u64; alias getMillis;
-        method duration::get_secs(&self) -> u64; alias getSecs;
+class Duration{
+    self_type Duration;
+    private constructor = empty;
+    static_method Duration::from_millis(millis: u64) -> Duration;
+    static_method Duration::from_secs(secs: u64) -> Duration;
+    method duration::get_millis(&self) -> u64; alias getMillis;
+    method duration::get_secs(&self) -> u64; alias getSecs;
+    foreigner_code r#"
+    @Override
+    /**
+     * This implementation calls native code, which means it's relatively slow.
+     */
+    public int hashCode() {
+        return Long.hashCode(this.getMillis());
     }
-);
+    public boolean equals(Object obj) {
+        if(obj instanceof Duration){
+            Duration d = (Duration) obj;
+            return d.getMillis() == this.getMillis();
+        }
+        return false;
+    }
+"#;
+});
 
 ///
 /// Full SDK Class Structure

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -124,14 +124,14 @@ class DeviceId {
 });
 
 foreigner_class!(
-    class UserUpdatePrivateKeyResult {
-        self_type UserUpdatePrivateKeyResult;
-        private constructor = empty;
-        /// Updated encrypted user private key
-        method user_update_private_key_result::user_master_private_key(&self) -> EncryptedPrivateKey; alias getUserMasterPrivateKey;
-        /// True if this user's master key requires rotation
-        method user_update_private_key_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
-        pre_build_generate_equals_and_hashcode UserUpdatePrivateKeyResult;
+class UserUpdatePrivateKeyResult {
+    self_type UserUpdatePrivateKeyResult;
+    private constructor = empty;
+    /// Updated encrypted user private key
+    method user_update_private_key_result::user_master_private_key(&self) -> EncryptedPrivateKey; alias getUserMasterPrivateKey;
+    /// True if this user's master key requires rotation
+    method user_update_private_key_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
+    pre_build_generate_equals_and_hashcode UserUpdatePrivateKeyResult;
 });
 
 foreigner_class!(
@@ -180,7 +180,6 @@ class UserAccessErr {
     method UserAccessErr::id(&self) -> UserId; alias getId;
     method UserAccessErr::err(&self) -> String; alias getErr;
     pre_build_generate_equals_and_hashcode UserAccessErr;
-
 });
 
 foreigner_class!(
@@ -191,7 +190,6 @@ class GroupAccessErr {
     method GroupAccessErr::id(&self) -> GroupId; alias getId;
     method GroupAccessErr::err(&self) -> String; alias getErr;
     pre_build_generate_equals_and_hashcode GroupAccessErr;
-
 });
 
 foreigner_class!(class UserWithKey {
@@ -200,7 +198,6 @@ foreigner_class!(class UserWithKey {
     method UserWithKey::user(&self) -> UserId; alias getUser;
     method UserWithKey::public_key(&self) -> PublicKey; alias getPublicKey;
     pre_build_generate_equals_and_hashcode UserWithKey;
-
 });
 
 foreigner_class!(class GroupUserList {
@@ -208,7 +205,6 @@ foreigner_class!(class GroupUserList {
     private constructor = empty;
     method GroupUserList::list(&self) -> Vec<UserId>; alias getList;
     pre_build_generate_equals_and_hashcode GroupUserList;
-
 });
 
 ///
@@ -267,7 +263,6 @@ class UserCreateResult {
     /// True if the private key of the user's keypair needs to be rotated, else false.
     method user_create_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
     pre_build_generate_equals_and_hashcode UserCreateResult;
-
 });
 
 foreigner_class!(
@@ -280,7 +275,6 @@ class UserResult {
     method user_result::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
     method user_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
     pre_build_generate_equals_and_hashcode UserResult;
-
 });
 
 foreigner_class!(
@@ -300,7 +294,6 @@ class UserDevice {
     /// the API request
     method UserDevice::is_current_device(&self) -> bool; alias isCurrentDevice;
     pre_build_generate_equals_and_hashcode UserDevice;
-
 });
 
 foreigner_class!(class DeviceCreateOpts {
@@ -328,7 +321,6 @@ class UserDeviceListResult {
     private constructor = empty;
     method user_device_list_result::result(&self) -> Vec<UserDevice>; alias getResult;
     pre_build_generate_equals_and_hashcode UserDeviceListResult;
-
 });
 
 ///
@@ -355,7 +347,6 @@ class GroupMetaResult{
     /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
     method group_meta_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
     pre_build_generate_equals_and_hashcode GroupMetaResult;
-
 });
 
 foreigner_class!(
@@ -386,7 +377,6 @@ class GroupCreateResult{
     /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
     method group_create_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
     pre_build_generate_equals_and_hashcode GroupCreateResult;
-
 });
 
 foreigner_class!(class GroupListResult{
@@ -394,7 +384,6 @@ foreigner_class!(class GroupListResult{
     private constructor = empty;
     method group_list_result::result(&self) -> Vec<GroupMetaResult>; alias getResult;
     pre_build_generate_equals_and_hashcode GroupListResult;
-
 });
 
 foreigner_class!(class GroupGetResult{
@@ -421,7 +410,6 @@ foreigner_class!(class GroupGetResult{
     /// null if the calling user is not a group admin, else a NullableBoolean of if the group private key needs rotation
     method group_get_result::needs_rotation(&self) -> Option<NullableBoolean>; alias getNeedsRotation;
     pre_build_generate_equals_and_hashcode GroupGetResult;
-
 });
 
 foreigner_class!(
@@ -434,7 +422,6 @@ class GroupUpdatePrivateKeyResult{
     /// the id of the group whose private key was rotated
     method group_update_private_key_result::id(&self) -> GroupId; alias getId;
     pre_build_generate_equals_and_hashcode GroupUpdatePrivateKeyResult;
-
 });
 
 foreigner_class!(
@@ -464,7 +451,6 @@ class GroupAccessEditErr{
     /// Get the reason for grant/revoke failure
     method access_edit_failure::error(&self) -> String; alias getError;
     pre_build_generate_equals_and_hashcode GroupAccessEditErr;
-
 });
 
 foreigner_class!(
@@ -477,7 +463,6 @@ class GroupAccessEditResult{
     /// Get the users whose access could not be modified
     method group_access_edit_result::failed(&self) -> Vec<GroupAccessEditErr>; alias getFailed;
     pre_build_generate_equals_and_hashcode GroupAccessEditResult;
-
 });
 
 ///
@@ -666,7 +651,6 @@ class SucceededResult {
     /// Get list of groups whose access was granted/revoked
     method document_access_change_result::SucceededResult::groups(&self) -> Vec<GroupId>; alias getGroups;
     pre_build_generate_equals_and_hashcode SucceededResult;
-
 });
 
 foreigner_class!(
@@ -681,7 +665,6 @@ class FailedResult {
     /// Utility method to check if the list of failures is empty
     method document_access_change_result::FailedResult::is_empty(&self) -> bool; alias isEmpty;
     pre_build_generate_equals_and_hashcode FailedResult;
-
 });
 
 foreigner_class!(

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -26,10 +26,10 @@ javacOptions in (Compile, compile) ++= Seq("-source", "1.8", "-target", "1.8")
 
 libraryDependencies ++= Seq(
   "com.pauldijou" %% "jwt-core" % "2.1.0",
-  "org.scalatest" %% "scalatest" % "3.0.8",
-  "org.scodec" %% "scodec-bits" % "1.1.12",
+  "org.scalatest" %% "scalatest" % "3.1.0",
+  "org.scodec" %% "scodec-bits" % "1.1.13",
   "com.github.melrief" %% "pureconfig" % "0.5.1",
-  "com.ironcorelabs" %% "cats-scalatest" % "3.0.0"
+  "com.ironcorelabs" %% "cats-scalatest" % "3.0.5"
 ).map(_ % "test")
 //Include the generated java as part of the source directories
 unmanagedSourceDirectories in Compile += baseDirectory.value / ".." / "java"

--- a/tests/src/test/scala/ironrust/DudeSuite.scala
+++ b/tests/src/test/scala/ironrust/DudeSuite.scala
@@ -1,10 +1,12 @@
 package ironrust
 
-import org.scalatest.{WordSpec, Matchers, BeforeAndAfterAll, OptionValues}
+import org.scalatest.{BeforeAndAfterAll, OptionValues}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import cats.scalatest.EitherValues
 
 //https://www.youtube.com/watch?v=LlLX6KSdWcQ
-trait DudeSuite extends WordSpec with BeforeAndAfterAll with Matchers with EitherValues with OptionValues {
+trait DudeSuite extends AnyWordSpec with BeforeAndAfterAll with Matchers with EitherValues with OptionValues {
   override def beforeAll(): Unit = {
     try {
       java.lang.System.loadLibrary("ironoxide_java")

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -171,64 +171,27 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
   }
 
-  "Class equality" should {
-    "work for Category" in {
+  "Classes" should {
+    "implement equals() and hashcode()" in {
       checkEqualsAndHashDeclared(Category.validate("test"))
-    }
-    "work for DataSubject" in {
       checkEqualsAndHashDeclared(DataSubject.validate("test"))
-
-    }
-    "work for DeviceCreateOpts" in {
       checkEqualsAndHashDeclared(new DeviceCreateOpts)
-    }
-    "work for DeviceId" in {
       checkEqualsAndHashDeclared(DeviceId.validate(42))
-    }
-    "work for DeviceName" in {
       checkEqualsAndHashDeclared(DeviceName.validate("test"))
-    }
-    "work for DeviceSigningKeyPair" in {
       checkEqualsAndHashDeclared(DeviceSigningKeyPair.validate(primaryTestUserSigningKeysBytes))
-    }
-    "work for DocumentEncryptOpts" in {
       checkEqualsAndHashDeclared(new DocumentEncryptOpts)
-    }
-    "work for DocumentId" in {
       checkEqualsAndHashDeclared(DocumentId.validate("test"))
-    }
-    "work for DocumentName" in {
       checkEqualsAndHashDeclared(DocumentName.validate("test"))
-    }
-    "work for Duration" in {
       checkEqualsAndHashDeclared(Duration.fromSecs(5))
       Duration.fromSecs(5) shouldBe Duration.fromMillis(5000)
-    }
-    "work for GroupCreateOpts" in {
       checkEqualsAndHashDeclared(new GroupCreateOpts)
-    }
-    "work for GroupId" in {
       checkEqualsAndHashDeclared(GroupId.validate("test"))
-    }
-    "work for GroupName" in {
       checkEqualsAndHashDeclared(GroupName.validate("test"))
-    }
-    "work for IronOxideConfig" in {
       checkEqualsAndHashDeclared(new IronOxideConfig(defaultPolicyCaching, defaultTimeout))
-    }
-    "work for PolicyCachingConfig" in {
       checkEqualsAndHashDeclared(new PolicyCachingConfig(123))
-    }
-    "work for PolicyGrant" in {
       checkEqualsAndHashDeclared(new PolicyGrant)
-    }
-    "work for Sensitivity" in {
       checkEqualsAndHashDeclared(Sensitivity.validate("test"))
-    }
-    "work for UserCreateOpts" in {
       checkEqualsAndHashDeclared(new UserCreateOpts)
-    }
-    "work for UserId" in {
       checkEqualsAndHashDeclared(UserId.validate("test"))
     }
   }

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -7,11 +7,11 @@ import scala.util.Try
 import scodec.bits.ByteVector
 
 class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
-  //Generates a random user ID and password to use for this full integration test
+  // Generates a random user ID and password to use for this full integration test
   val primaryTestUserId = Try(UserId.validate(java.util.UUID.randomUUID.toString)).toEither.value
   val primaryTestUserPassword = java.util.UUID.randomUUID.toString
 
-  //Stores record of integration test users device context parts that are then used to initialize the SDK
+  // Stores record of integration test users device context parts that are then used to initialize the SDK
   var primaryTestUserSegmentId = 0L
   var primaryTestUserPrivateDeviceKeyBytes: Array[Byte] = null
   var primaryTestUserSigningKeysBytes: Array[Byte] = null
@@ -27,9 +27,9 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   val defaultPolicyCaching = new PolicyCachingConfig
 
-  val shortTimeout = Duration.from_millis(5)
-  val defaultTimeout = Duration.from_secs(30)
-  val longTimeout = Duration.from_secs(30)
+  val shortTimeout = Duration.fromMillis(5)
+  val defaultTimeout = Duration.fromSecs(30)
+  val longTimeout = Duration.fromSecs(30)
 
   val shortConfig = new IronOxideConfig(defaultPolicyCaching, shortTimeout)
   val defaultConfig = new IronOxideConfig
@@ -46,6 +46,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
         Try(IronOxide.userCreate(jwt, primaryTestUserPassword, UserCreateOpts.create(true), defaultTimeout)).toEither
       val createResult = resp.value
 
+      createResult.equals(createResult) shouldBe true
       createResult.getUserPublicKey.asBytes should have length 64
       createResult.getNeedsRotation shouldBe true
       createResult.getUserPublicKey.equals(createResult.getUserPublicKey) shouldBe true
@@ -73,7 +74,6 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     "fails for user that does not exist" in {
       val jwt = JwtHelper.generateValidJwt("not a real user")
       val resp = Try(IronOxide.userVerify(jwt, null)).toEither
-
       val verifyResult = resp.value
 
       verifyResult.isPresent shouldBe false
@@ -82,11 +82,10 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     "successfully verify existing user" in {
       val jwt = JwtHelper.generateValidJwt(primaryTestUserId.getId)
       val resp = Try(IronOxide.userVerify(jwt, defaultTimeout)).toEither
-
       val verifyResult = resp.value
 
       verifyResult.isPresent shouldBe true
-
+      verifyResult.equals(verifyResult) shouldBe true
       verifyResult.get.getAccountId shouldBe primaryTestUserId
       verifyResult.get.getSegmentId shouldBe 2013
       verifyResult.get.getNeedsRotation shouldBe true
@@ -106,12 +105,13 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val jwt2 = JwtHelper.generateValidJwt(secondaryTestUserId.getId)
       val deviceName = Try(DeviceName.validate("myDevice")).toEither.value
       val newDeviceResult = Try(
-        IronOxide.generateNewDevice(jwt, primaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone), null)
+        IronOxide.generateNewDevice(jwt, primaryTestUserPassword, DeviceCreateOpts.create(deviceName), null)
       ).toEither.value
       val secondDeviceResult = Try(
-        IronOxide.generateNewDevice(jwt2, secondaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone), null)
+        IronOxide.generateNewDevice(jwt2, secondaryTestUserPassword, DeviceCreateOpts.create(deviceName), null)
       ).toEither.value
 
+      newDeviceResult.equals(newDeviceResult) shouldBe true
       newDeviceResult.getCreated shouldBe newDeviceResult.getLastUpdated
       newDeviceResult.getName.isPresent shouldBe true
       newDeviceResult.getName.get shouldBe deviceName
@@ -146,10 +146,86 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
       sdk = IronOxide.initialize(deviceContext, defaultConfig)
       val deviceList = sdk.userListDevices.getResult
+
+      newDeviceResult.getDevicePrivateKey.equals(newDeviceResult.getDevicePrivateKey) shouldBe true
+      deviceContext.equals(deviceContext) shouldBe true
       deviceList.length shouldBe 1
       deviceList.head.getId.getId shouldBe a[java.lang.Long]
       deviceList.head.getName.isPresent shouldBe true
       deviceList.head.getName.get shouldBe deviceName
+    }
+  }
+
+  "Class equality" should {
+    "work for Category" in {
+      val cat1 = Category.validate("test")
+      val cat2 = Category.validate("test")
+      cat1.equals(cat2) shouldBe true
+    }
+    "work for DataSubject" in {
+      val ds1 = DataSubject.validate("test")
+      val ds2 = DataSubject.validate("test")
+      ds1.equals(ds2) shouldBe true
+    }
+    "work for DeviceId" in {
+      val id1 = DeviceId.validate(42)
+      val id2 = DeviceId.validate(42)
+      id1.equals(id2) shouldBe true
+    }
+    "work for DeviceName" in {
+      val name1 = DeviceName.validate("test")
+      val name2 = DeviceName.validate("test")
+      name1.equals(name2) shouldBe true
+    }
+    "work for DeviceSigningKeyPair" in {
+      val key1 = DeviceSigningKeyPair.validate(primaryTestUserSigningKeysBytes)
+      val key2 = DeviceSigningKeyPair.validate(primaryTestUserSigningKeysBytes)
+      key1.equals(key2) shouldBe true
+    }
+    "work for DocumentId" in {
+      val id1 = DocumentId.validate("test")
+      val id2 = DocumentId.validate("test")
+      id1.equals(id2) shouldBe true
+    }
+    "work for DocumentName" in {
+      val name1 = DocumentName.validate("test")
+      val name2 = DocumentName.validate("test")
+      name1.equals(name2) shouldBe true
+    }
+    "work for Duration" in {
+      val d1 = Duration.fromSecs(5)
+      val d2 = Duration.fromMillis(5000)
+      d1.equals(d2) shouldBe true
+    }
+    "work for GroupId" in {
+      val id1 = GroupId.validate("test")
+      val id2 = GroupId.validate("test")
+      id1.equals(id2) shouldBe true
+    }
+    "work for GroupName" in {
+      val name1 = GroupName.validate("test")
+      val name2 = GroupName.validate("test")
+      name1.equals(name2) shouldBe true
+    }
+    "work for IronOxideConfig" in {
+      val config1 = new IronOxideConfig(defaultPolicyCaching, defaultTimeout)
+      val config2 = new IronOxideConfig(defaultPolicyCaching, defaultTimeout)
+      config1.equals(config2) shouldBe true
+    }
+    "work for PolicyCachingConfig" in {
+      val policy1 = new PolicyCachingConfig(123)
+      val policy2 = new PolicyCachingConfig(123)
+      policy1.equals(policy2) shouldBe true
+    }
+    "work for Sensitivity" in {
+      val sen1 = Sensitivity.validate("test")
+      val sen2 = Sensitivity.validate("test")
+      sen1.equals(sen2) shouldBe true
+    }
+    "work for UserId" in {
+      val id1 = UserId.validate("test")
+      val id2 = UserId.validate("test")
+      id1.equals(id2) shouldBe true
     }
   }
 
@@ -166,7 +242,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val deviceName = DeviceName.validate("device")
       val deviceContext =
         new DeviceContext(
-          IronOxide.generateNewDevice(jwt, secondaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone), null)
+          IronOxide.generateNewDevice(jwt, secondaryTestUserPassword, DeviceCreateOpts.create(deviceName), null)
         )
       val json = deviceContext.toJsonString
       val accountId = deviceContext.getAccountId.getId
@@ -206,8 +282,11 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
         Try(IronOxide.generateNewDevice(jwt, primaryTestUserPassword, new DeviceCreateOpts, null)).toEither
       val dev3 = new DeviceContext(deviceResp2.value)
 
-      val deviceList = Try(sdk.userListDevices).toEither.value.getResult
+      val deviceListResult = Try(sdk.userListDevices).toEither.value
+      val deviceList = deviceListResult.getResult
 
+      deviceListResult.equals(deviceListResult) shouldBe true
+      deviceList.equals(deviceList) shouldBe true
       deviceList.length shouldBe 3 // We have the primary device as well as secondary and tertiary devices generated above
       deviceList.head.getId.getId shouldBe a[java.lang.Long]
       deviceList.head.getName.isPresent shouldBe true //Our first device (createDeviceContext) from above does have a name
@@ -229,7 +308,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "Delete valid device" in {
-      val result = Try(sdk.userDeleteDevice(secondaryDeviceId.clone)).toEither
+      val result = Try(sdk.userDeleteDevice(secondaryDeviceId)).toEither
 
       result.value shouldBe secondaryDeviceId
 
@@ -265,9 +344,11 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "Return both for ids that do exist" in {
-      val result = Try(sdk.userGetPublicKey(List(primaryTestUserId, secondaryTestUserId).toArray)).toEither
+      val result = Try(sdk.userGetPublicKey(List(primaryTestUserId, secondaryTestUserId).toArray)).toEither.value
+
+      result.head.equals(result.head)
       //Sort the values just to make sure the assertion doesn't fail due to ordering being off.
-      result.value.toList
+      result.toList
         .map(_.getUser.getId)
         .sorted shouldBe List(primaryTestUserId.getId, secondaryTestUserId.getId).sorted
     }
@@ -277,14 +358,16 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     "Create valid group" in {
       val groupName = Try(GroupName.validate("a name")).toEither.value
       val groupCreateResult =
-        sdk.groupCreate(GroupCreateOpts.create(null, groupName.clone, true, true, null, Array(), Array(), true))
+        sdk.groupCreate(GroupCreateOpts.create(null, groupName, true, true, null, Array(), Array(), true))
 
+      groupCreateResult.equals(groupCreateResult) shouldBe true
       groupCreateResult.getId.getId.length shouldBe 32 //gooid
       groupCreateResult.getName.get shouldBe groupName
       groupCreateResult.isAdmin shouldBe true
       groupCreateResult.isMember shouldBe true
       groupCreateResult.getCreated should not be null
       groupCreateResult.getLastUpdated shouldBe groupCreateResult.getCreated
+      groupCreateResult.getAdminList.equals(groupCreateResult.getAdminList)
       groupCreateResult.getAdminList.getList should have length 1
       groupCreateResult.getAdminList.getList.head shouldBe primaryTestUserId
       groupCreateResult.getMemberList.getList should have length 1
@@ -307,7 +390,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val groupName = Try(GroupName.validate("no member")).toEither.value
       val groupCreateResult =
         sdk.groupCreate(
-          GroupCreateOpts.create(null, groupName.clone, true, false, null, Array(), Array(), false)
+          GroupCreateOpts.create(null, groupName, true, false, null, Array(), Array(), false)
         )
 
       groupCreateResult.getId.getId.length shouldBe 32 //gooid
@@ -325,6 +408,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
   "Group Private Key Rotate" should {
     "Successfully rotate a valid group" in {
       val rotateResult = sdk.groupRotatePrivateKey(validGroupId)
+      rotateResult.equals(rotateResult) shouldBe true
       rotateResult.getNeedsRotation shouldBe false
       rotateResult.getId shouldBe validGroupId
     }
@@ -343,14 +427,15 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     "Return previously created group" in {
       val groupResult = sdk.groupList.getResult
 
+      groupResult.equals(groupResult) shouldBe true
       groupResult.length shouldBe 3
-
       groupResult.head.getId.getId.length shouldBe 32 //gooid
       groupResult.head.getName.get.getName shouldBe "a name"
       groupResult.head.isAdmin shouldBe true
       groupResult.head.isMember shouldBe true
       groupResult.head.getCreated should not be null
       groupResult.head.getLastUpdated should be > groupResult.head.getCreated
+      groupResult.head.equals(groupResult.head) shouldBe true
     }
   }
 
@@ -366,6 +451,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val resp = Try(sdk.groupGetMetadata(validGroupId)).toEither
       val group = resp.value
 
+      group.equals(group) shouldBe true
       group.getId.getId.length shouldBe 32
       group.getId shouldBe validGroupId
       group.getName.get.getName shouldBe "a name"
@@ -427,9 +513,10 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     "change name of group" in {
       val newGroupName = Try(GroupName.validate("new name")).toEither.value
 
-      val updateResp = Try(sdk.groupUpdateName(validGroupId, newGroupName.clone)).toEither
-
+      val updateResp = Try(sdk.groupUpdateName(validGroupId, newGroupName)).toEither
       val updatedGroup = updateResp.value
+
+      updatedGroup.getNeedsRotation.equals(updatedGroup.getNeedsRotation) shouldBe true
       updatedGroup.getId shouldBe validGroupId
       updatedGroup.getName.get shouldBe newGroupName
       updatedGroup.getCreated should not be null
@@ -456,6 +543,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val removeMember = removeMemberResp.value
 
       removeMember.getSucceeded.toList should have length 1
+      removeMember.getSucceeded.head.equals(removeMember.getSucceeded.head) shouldBe true
       removeMember.getSucceeded.toList.head shouldBe primaryTestUserId
       removeMember.getFailed.toList should have length 1
       removeMember.getFailed.toList.head.getUser shouldBe randomUser
@@ -478,7 +566,10 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val addMemberResp = Try(sdk.groupAddMembers(validGroupId, List(primaryTestUserId).toArray)).toEither
 
       val addMember = addMemberResp.value
+
+      addMember.equals(addMember) shouldBe true
       addMember.getFailed.toList should have length 1
+      addMember.getFailed.head.equals(addMember.getFailed.head) shouldBe true
       addMember.getSucceeded.toList should have length 0
     }
   }
@@ -543,8 +634,10 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val data: Array[Byte] = List(1, 2, 3).map(_.toByte).toArray
       val docName = Try(DocumentName.validate("name")).toEither.value
       val maybeResult =
-        Try(sdk.documentEncrypt(data, DocumentEncryptOpts.create(null, docName.clone, true, Array(), Array(), null))).toEither
+        Try(sdk.documentEncrypt(data, DocumentEncryptOpts.create(null, docName, true, Array(), Array(), null))).toEither
       val result = maybeResult.value
+
+      result.equals(result) shouldBe true
       result.getName.get shouldBe docName
       result.getId.getId.length shouldBe 32
     }
@@ -553,6 +646,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val data: Array[Byte] = List(10, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(sdk.documentEncrypt(data, new DocumentEncryptOpts)).toEither
       val result = maybeResult.value
+
       result.getId.getId.length shouldBe 32
       result.getName.isPresent shouldBe false
 
@@ -563,6 +657,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
       val decryptedResult = maybeDecrypt.value
 
+      decryptedResult.equals(decryptedResult) shouldBe true
       decryptedResult.getId.getId.length shouldBe 32
       decryptedResult.getName.isPresent shouldBe false
       decryptedResult.getDecryptedData shouldBe data
@@ -601,6 +696,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
         )
       ).toEither
       val result = maybeResult.value
+
       result.getChanged.getUsers should have length 1
       result.getChanged.getUsers.head.getId shouldEqual primaryTestUserId.getId
       result.getChanged.getGroups should have length 1
@@ -628,7 +724,9 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       result.getChanged.getGroups should have length 0
 
       // the invalid stuff should have errored
+      result.getErrors.equals(result.getErrors) shouldBe true
       result.getErrors.getUsers should have length 1
+      result.getErrors.getUsers.head.equals(result.getErrors.getUsers.head) shouldBe true
       result.getErrors.getUsers.head.getId.getId shouldBe notAUser.getId
       result.getErrors.getUsers.head.getErr shouldBe "User could not be found"
       result.getErrors.getGroups should have length 1
@@ -648,17 +746,19 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val rotatedDecryptResult = Try(sdk.documentDecrypt(encryptResult.getEncryptedData)).toEither.value
 
       rotatedPublicKey shouldBe originalPublicKey
+      rotateResult.equals(rotateResult) shouldBe true
       rotateResult.getNeedsRotation shouldBe false
       rotatedDecryptResult.getDecryptedData shouldBe decryptResult.getDecryptedData
       rotatedDecryptResult.getId shouldBe decryptResult.getId
       rotatedDecryptResult.getName shouldBe decryptResult.getName
+      rotateResult.getUserMasterPrivateKey.equals(rotateResult.getUserMasterPrivateKey) shouldBe true
       rotateResult.equals(rotateResult) shouldBe true
     }
     "create a new device after rotation" in {
       val jwt = JwtHelper.generateValidJwt(primaryTestUserId.getId)
       val deviceName = Try(DeviceName.validate("newdevice")).toEither.value
       val newDeviceResult = Try(
-        IronOxide.generateNewDevice(jwt, primaryTestUserPassword, DeviceCreateOpts.create(deviceName.clone), null)
+        IronOxide.generateNewDevice(jwt, primaryTestUserPassword, DeviceCreateOpts.create(deviceName), null)
       ).toEither.value
       newDeviceResult.getAccountId.getId shouldBe primaryTestUserId.getId
     }
@@ -671,7 +771,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val sdk = IronOxide.initialize(secondaryDeviceContext, defaultConfig)
       val groupName = Try(GroupName.validate("a name")).toEither.value
       val groupCreateResult =
-        sdk.groupCreate(GroupCreateOpts.create(null, groupName.clone, true, true, null, Array(), Array(), true))
+        sdk.groupCreate(GroupCreateOpts.create(null, groupName, true, true, null, Array(), Array(), true))
       val originalPublicKey = sdk.userGetPublicKey(Array(secondaryTestUserId))(0).getPublicKey.asBytes
       val data: Array[Byte] = List(3, 1, 4).map(_.toByte).toArray
       val encryptResult = Try(sdk.documentEncrypt(data, new DocumentEncryptOpts)).toEither.value
@@ -707,12 +807,16 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       val data: Array[Byte] = List(10, 2, 3).map(_.toByte).toArray
       val maybeResult = Try(sdk.advancedDocumentEncryptUnmanaged(data, new DocumentEncryptOpts)).toEither
       val result = maybeResult.value
+
+      result.equals(result) shouldBe true
       result.getId.getId.length shouldBe 32
 
       val maybeDecrypt =
         Try(sdk.advancedDocumentDecryptUnmanaged(result.getEncryptedData, result.getEncryptedDeks)).toEither
       val decryptedResult = maybeDecrypt.value
 
+      decryptedResult.getAccessViaUserOrGroup.equals(decryptedResult.getAccessViaUserOrGroup)
+      decryptedResult.equals(decryptedResult) shouldBe true
       decryptedResult.getId.getId shouldBe result.getId.getId
       decryptedResult.getDecryptedData shouldBe data
       decryptedResult.getAccessViaUserOrGroup.getId shouldBe primaryTestUserId.getId
@@ -820,7 +924,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     "successfully update to new name" in {
       val newDocName = Try(DocumentName.validate("new name")).toEither.value
 
-      val maybeUpdate = Try(sdk.documentUpdateName(validDocumentId, newDocName.clone)).toEither
+      val maybeUpdate = Try(sdk.documentUpdateName(validDocumentId, newDocName)).toEither
 
       val result = maybeUpdate.value
 
@@ -839,7 +943,12 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Document List" should {
     "Return previously created documents" in {
-      sdk.documentList.getResult should have length 6
+      val listResult = sdk.documentList
+      val listMeta = listResult.getResult
+
+      listMeta.equals(listMeta) shouldBe true
+      listResult.equals(listResult) shouldBe true
+      listMeta should have length 6
     }
   }
 
@@ -856,10 +965,13 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
       val doc = maybeDoc.value
 
+      doc.equals(doc) shouldBe true
       doc.getId shouldBe validDocumentId
       doc.getName.isPresent shouldBe false
       doc.getAssociationType shouldBe AssociationType.Owner
+      doc.getAssociationType.equals(doc.getAssociationType) shouldBe true
       doc.getVisibleToUsers should have length 1
+      doc.getVisibleToUsers.head.equals(doc.getVisibleToUsers.head) shouldBe true
       doc.getVisibleToUsers.head.getId shouldBe primaryTestUserId
       doc.getVisibleToGroups should have length 0
     }
@@ -896,8 +1008,10 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       ).toEither
       val grantResult = maybeResult.value
       val success = grantResult.getChanged
+
       success.getUsers should have length 1
       success.getGroups should have length 1
+      grantResult.equals(grantResult) shouldBe true
       grantResult.getErrors.isEmpty shouldBe false
       grantResult.getErrors.getUsers should have length 1
       grantResult.getErrors.getGroups should have length 1

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -937,8 +937,8 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
       doc.getId shouldBe validDocumentId
       doc.getName.isPresent shouldBe false
       doc.getAssociationType shouldBe AssociationType.Owner
-      // doc.getAssociationType shouldBe doc2.getAssociationType
-      // doc.hashCode shouldBe doc2.hashCode
+      doc.getAssociationType shouldBe doc2.getAssociationType
+      doc.getAssociationType.hashCode shouldBe doc2.getAssociationType.hashCode
       doc.getVisibleToUsers should have length 1
       checkEqualsAndHashDeclared(doc.getVisibleToUsers.head)
       doc.getVisibleToUsers.head.getId shouldBe primaryTestUserId

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -48,6 +48,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
       createResult.getUserPublicKey.asBytes should have length 64
       createResult.getNeedsRotation shouldBe true
+      createResult.getUserPublicKey.equals(createResult.getUserPublicKey) shouldBe true
     }
 
     "successfully create a 2nd new user" in {

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -160,72 +160,86 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     "work for Category" in {
       val cat1 = Category.validate("test")
       val cat2 = Category.validate("test")
-      cat1.equals(cat2) shouldBe true
+      cat1 shouldBe cat2
+      cat1.hashCode shouldBe cat2.hashCode
     }
     "work for DataSubject" in {
       val ds1 = DataSubject.validate("test")
       val ds2 = DataSubject.validate("test")
-      ds1.equals(ds2) shouldBe true
+      ds1 shouldBe ds2
+      ds1.hashCode shouldBe ds2.hashCode
     }
     "work for DeviceId" in {
       val id1 = DeviceId.validate(42)
       val id2 = DeviceId.validate(42)
-      id1.equals(id2) shouldBe true
+      id1 shouldBe id2
+      id1.hashCode shouldBe id2.hashCode
     }
     "work for DeviceName" in {
       val name1 = DeviceName.validate("test")
       val name2 = DeviceName.validate("test")
-      name1.equals(name2) shouldBe true
+      name1 shouldBe name2
+      name1.hashCode shouldBe name2.hashCode
     }
     "work for DeviceSigningKeyPair" in {
       val key1 = DeviceSigningKeyPair.validate(primaryTestUserSigningKeysBytes)
       val key2 = DeviceSigningKeyPair.validate(primaryTestUserSigningKeysBytes)
-      key1.equals(key2) shouldBe true
+      key1 shouldBe key2
+      key1.hashCode shouldBe key2.hashCode
     }
     "work for DocumentId" in {
       val id1 = DocumentId.validate("test")
       val id2 = DocumentId.validate("test")
-      id1.equals(id2) shouldBe true
+      id1 shouldBe id2
+      id1.hashCode shouldBe id2.hashCode
     }
     "work for DocumentName" in {
       val name1 = DocumentName.validate("test")
       val name2 = DocumentName.validate("test")
-      name1.equals(name2) shouldBe true
+      name1 shouldBe name2
+      name1.hashCode shouldBe name2.hashCode
     }
     "work for Duration" in {
       val d1 = Duration.fromSecs(5)
       val d2 = Duration.fromMillis(5000)
-      d1.equals(d2) shouldBe true
+      d1 shouldBe d2
+      d1.hashCode shouldBe d2.hashCode
     }
     "work for GroupId" in {
       val id1 = GroupId.validate("test")
       val id2 = GroupId.validate("test")
-      id1.equals(id2) shouldBe true
+      id1 shouldBe id2
+      id1.hashCode shouldBe id2.hashCode
     }
     "work for GroupName" in {
       val name1 = GroupName.validate("test")
       val name2 = GroupName.validate("test")
-      name1.equals(name2) shouldBe true
+      name1 shouldBe name2
+      name1.hashCode shouldBe name2.hashCode
     }
     "work for IronOxideConfig" in {
       val config1 = new IronOxideConfig(defaultPolicyCaching, defaultTimeout)
       val config2 = new IronOxideConfig(defaultPolicyCaching, defaultTimeout)
-      config1.equals(config2) shouldBe true
+      config1 shouldBe config2
+      config1.hashCode shouldBe config2.hashCode
     }
     "work for PolicyCachingConfig" in {
       val policy1 = new PolicyCachingConfig(123)
       val policy2 = new PolicyCachingConfig(123)
-      policy1.equals(policy2) shouldBe true
+      policy1 shouldBe policy2
+      policy1.hashCode shouldBe policy2.hashCode
     }
     "work for Sensitivity" in {
       val sen1 = Sensitivity.validate("test")
       val sen2 = Sensitivity.validate("test")
-      sen1.equals(sen2) shouldBe true
+      sen1 shouldBe sen2
+      sen1.hashCode shouldBe sen2.hashCode
     }
     "work for UserId" in {
       val id1 = UserId.validate("test")
       val id2 = UserId.validate("test")
-      id1.equals(id2) shouldBe true
+      id1 shouldBe id2
+      id1.hashCode shouldBe id2.hashCode
     }
   }
 

--- a/tests/src/test/scala/ironrust/FullIntegrationTest.scala
+++ b/tests/src/test/scala/ironrust/FullIntegrationTest.scala
@@ -236,8 +236,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
         Try(IronOxide.generateNewDevice(jwt, primaryTestUserPassword, new DeviceCreateOpts, null)).toEither
       val dev3 = new DeviceContext(deviceResp2.value)
 
-      val deviceListResult = Try(sdk.userListDevices).toEither.value
-      val deviceList = deviceListResult.getResult
+      val deviceList = Try(sdk.userListDevices).toEither.value.getResult
 
       deviceList.length shouldBe 3 // We have the primary device as well as secondary and tertiary devices generated above
       deviceList.head.getId.getId shouldBe a[java.lang.Long]
@@ -296,10 +295,10 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
     }
 
     "Return both for ids that do exist" in {
-      val result = Try(sdk.userGetPublicKey(List(primaryTestUserId, secondaryTestUserId).toArray)).toEither.value
+      val result = Try(sdk.userGetPublicKey(List(primaryTestUserId, secondaryTestUserId).toArray)).toEither
 
       //Sort the values just to make sure the assertion doesn't fail due to ordering being off.
-      result.toList
+      result.value.toList
         .map(_.getUser.getId)
         .sorted shouldBe List(primaryTestUserId.getId, secondaryTestUserId.getId).sorted
     }
@@ -373,8 +372,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Group List" should {
     "Return previously created group" in {
-      val groupList = sdk.groupList
-      val groupResult = groupList.getResult
+      val groupResult = sdk.groupList.getResult
 
       groupResult.length shouldBe 3
       groupResult.head.getId.getId.length shouldBe 32 //gooid
@@ -874,10 +872,7 @@ class FullIntegrationTest extends DudeSuite with CancelAfterFailure {
 
   "Document List" should {
     "Return previously created documents" in {
-      val listResult = sdk.documentList
-      val listMeta = listResult.getResult
-
-      listMeta should have length 6
+      sdk.documentList.getResult should have length 6
     }
   }
 


### PR DESCRIPTION
Used Rust's hash to add `hashCode()` functionality to all classes.

Used Rust's eq to add `rustEq()` to all classes. This then requires foreign code to make the function signatures line up. This code is very copy-and-paste, so macros would be a good way to avoid duplication. Unfortunately, rust_swig creates the java files during the build script, so macro expansion hasn't happened yet.
My current solution is to make a "fake" macro expander that runs during the build script. It looks for  `pre_build_generate_equality TYPE`, and replaces it with the foreign code for the class. It outputs that into a `lib.rs.out` in the output directory, which is then what the rust_swig expander uses to create the java files.
I think that this is reasonable for a few reasons:
- `pre_build_generate_equality` is easily searchable within our code
- The "fake" macro expansion is similar to what rust_swig itself is doing, so I purposely tried to make the call not look like regular rust. 
- The foreign code is not something that people should need to be seeing, so moving it into the `build.rs` will make the file easier to understand.

But if we decide that the fake macro expansion is too confusing, it will be easy to undo and just place the `foreign_code` back into every `foreign_class`.

Other misc changes:
- Running `ulimit -Sn 10000` in the Travis script before running the tests seems to fix the issue with OSX tests ("failed to lookup address information"). The previous limit was 30,000 for Linux and 256 for OSX.
- Adding `.rustfmt_bindings(true)` to the rust_swig generator makes the generated file readable and not give headaches to syntax highlighting.
- Adding `.remove_not_generated_files_from_output_directory(true)` to the rust_swig generator makes it remove unused java files during generation. This will be beneficial whenever we rename or remove a class.