### PR TITLE
Add ability to enable/disable users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "ironoxide"
-version = "4.3.1"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2f053fe51aa28bdf6a1a77bdf1e7961a73edd5b829c322c5b8b87867ce53ae"
+checksum = "c4f7b956c62b23ac7b252e0941f68cda485a77bdba6ccd1ebb912aefbd9318a1"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ bindgen = "0.72"
 cfg-if = "1"
 env_logger = { version = "0.11", default-features = false }
 flapigen = { git = "https://github.com/Dushistov/flapigen-rs.git", rev = "49a59f68" }
-ironoxide = { version = "4.3", features = [
+ironoxide = { version = "4.4", features = [
     "blocking",
     "beta",
     "tls-rustls",

--- a/common/lib.rs
+++ b/common/lib.rs
@@ -405,6 +405,19 @@ mod user_create_result {
     pub fn needs_rotation(u: &UserCreateResult) -> bool {
         u.needs_rotation()
     }
+    pub fn status(u: &UserCreateResult) -> UserStatus {
+        u.status()
+    }
+}
+
+mod user_status {
+    use super::*;
+    pub fn enabled() -> UserStatus {
+        UserStatus::Enabled
+    }
+    pub fn disabled() -> UserStatus {
+        UserStatus::Disabled
+    }
 }
 
 mod user_result {
@@ -1086,6 +1099,20 @@ fn user_rotate_private_key(
     password: &str,
 ) -> Result<UserUpdatePrivateKeyResult, String> {
     Ok(sdk.user_rotate_private_key(password)?)
+}
+fn user_disable_self(sdk: &IronOxide) -> Result<UserCreateResult, String> {
+    Ok(sdk.user_disable_self()?)
+}
+fn user_update_status(
+    jwt: &Jwt,
+    status: &UserStatus,
+    timeout: Option<&Duration>,
+) -> Result<UserCreateResult, String> {
+    Ok(IronOxide::user_update_status(
+        jwt,
+        *status,
+        timeout.copied(),
+    )?)
 }
 fn document_list(sdk: &IronOxide) -> Result<DocumentListResult, String> {
     Ok(sdk.document_list()?)

--- a/common/lib.rs.in
+++ b/common/lib.rs.in
@@ -302,6 +302,17 @@ class DeviceAddResult {
 ///
 
 foreign_class!(
+/// Status of a user. Disabled users cannot call any SDK functions; a user can re-enable a
+/// disabled user with userUpdateStatus.
+class UserStatus {
+    self_type UserStatus;
+    private constructor = empty;
+    fn user_status::enabled() -> UserStatus; alias enabled;
+    fn user_status::disabled() -> UserStatus; alias disabled;
+    pre_build_generate_equals_and_hashcode UserStatus;
+});
+
+foreign_class!(
 /// Keypair for a newly created user.
 class UserCreateResult {
     self_type UserCreateResult;
@@ -309,6 +320,8 @@ class UserCreateResult {
     fn user_create_result::user_public_key(&self) -> PublicKey; alias getUserPublicKey;
     /// True if the private key of the user's keypair needs to be rotated, else false.
     fn user_create_result::needs_rotation(&self) -> bool; alias getNeedsRotation;
+    /// Current status of the user.
+    fn user_create_result::status(&self) -> UserStatus; alias getStatus;
     pre_build_generate_equals_and_hashcode UserCreateResult;
 });
 
@@ -968,6 +981,20 @@ class IronOxide {
     /// @param password password to unlock the current user's master private key
     /// @return The (encrypted) updated private key and associated metadata
     fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult, String>; alias userRotatePrivateKey;
+    /// Disable the calling user. The user remains a member of any groups, but cannot make
+    /// further authenticated SDK calls. Use {@link #userUpdateStatus(Jwt, UserStatus, Duration)}
+    /// with a JWT to re-enable a disabled user.
+    ///
+    /// @return updated user metadata
+    fn user_disable_self(&self) -> Result<UserCreateResult, String>; alias userDisableSelf;
+    /// Update a user's status (enabled or disabled) via a signed JWT, without requiring an
+    /// initialized SDK instance. This is the only way to re-enable a disabled user.
+    ///
+    /// @param jwt      valid IronCore or Auth0 JWT for the user whose status should change
+    /// @param status   new user status {@link UserStatus}
+    /// @param timeout  timeout for this operation or `null` for no timeout
+    /// @return updated user metadata
+    fn user_update_status(jwt: &Jwt, status: &UserStatus, timeout: Option<&Duration>) -> Result<UserCreateResult, String>; alias userUpdateStatus;
     /// List all of the documents that the current user is able to decrypt.
     ///
     /// @return {@link DocumentListResult} struct with vec of metadata about each document the user can decrypt.

--- a/java/tests/src/test/scala/ironoxide/UserTests.scala
+++ b/java/tests/src/test/scala/ironoxide/UserTests.scala
@@ -235,6 +235,41 @@ class UserTests extends TestSuite {
     }
   }
 
+  "User Status" should {
+    "expose enabled and disabled factories distinguishable via equality" in {
+      UserStatus.enabled shouldBe UserStatus.enabled
+      UserStatus.disabled shouldBe UserStatus.disabled
+      UserStatus.enabled should not be UserStatus.disabled
+    }
+    "report Enabled on a freshly created user" in {
+      val userId = UserId.validate(java.util.UUID.randomUUID.toString)
+      val jwt = generateValidJwt(userId.getId)
+      val createResult =
+        Try(IronOxide.userCreate(jwt, testUsersPassword, new UserCreateOpts(true), null)).toEither.value
+      createResult.getStatus shouldBe UserStatus.enabled
+    }
+  }
+
+  "User Disable Self and Update Status" should {
+    "disable the calling user and re-enable via JWT" in {
+      val dc = createUserAndDevice()
+      val jwt = generateValidJwt(dc.getAccountId.getId)
+      val sdk = IronOxide.initialize(dc, new IronOxideConfig)
+
+      val disabled = Try(sdk.userDisableSelf()).toEither.value
+      disabled.getStatus shouldBe UserStatus.disabled
+
+      // Disabled users cannot make authenticated SDK calls.
+      val postDisable = Try(sdk.userListDevices)
+      postDisable.isFailure shouldBe true
+
+      // Re-enable via JWT (no SDK instance required).
+      val reenabled =
+        Try(IronOxide.userUpdateStatus(jwt, UserStatus.enabled, null)).toEither.value
+      reenabled.getStatus shouldBe UserStatus.enabled
+    }
+  }
+
   "Device Delete" should {
     "delete a user's device" in {
       val jwt = generateValidJwt()


### PR DESCRIPTION
The integration tests are only added to Java because the other test fixtures don't currently have JWT generation pulled in, so they have no way to re-enable a disabled user. And because the tests use a hard-coded device context, a single run would break the next test runs.